### PR TITLE
Refactor: Remove `{.pure.}` enum annotation

### DIFF
--- a/src/arguments.nim
+++ b/src/arguments.nim
@@ -1,14 +1,14 @@
 import std/[options, os, parseopt, strformat, strutils]
 
 type
-  Action* {.pure.} = enum
-    Sync, Check, Help, Version
+  Action* = enum
+    actSync, actCheck, actHelp, actVersion
 
-  Mode* {.pure.} = enum
-    Choose, IncludeMissing, ExcludeMissing
+  Mode* = enum
+    modeChoose, modeIncludeMissing, modeExcludeMissing
 
-  Verbosity* {.pure.} = enum
-    Quiet, Normal, Detailed
+  Verbosity* = enum
+    verQuiet, verNormal, verDetailed
 
   Arguments* = object
     action*: Action
@@ -45,22 +45,22 @@ proc showVersion* =
 
 proc parseMode(mode: string): Mode =
   case mode.toLowerAscii
-  of "c", "choose": Mode.Choose
-  of "i", "include": Mode.IncludeMissing
-  of "e", "exclude": Mode.ExcludeMissing
-  else: Mode.Choose
+  of "c", "choose": modeChoose
+  of "i", "include": modeIncludeMissing
+  of "e", "exclude": modeExcludeMissing
+  else: modeChoose
 
 proc parseVerbosity(verbosity: string): Verbosity =
   case verbosity.toLowerAscii
-  of "q", "quiet": Verbosity.Quiet
-  of "n", "normal": Verbosity.Normal
-  of "d", "detailed": Verbosity.Detailed
-  else: Verbosity.Normal
+  of "q", "quiet": verQuiet
+  of "n", "normal": verNormal
+  of "d", "detailed": verDetailed
+  else: verNormal
 
 proc parseArguments*: Arguments =
-  result.action = Action.Sync
-  result.verbosity = Verbosity.Normal
-  result.mode = Mode.Choose
+  result.action = actSync
+  result.verbosity = verNormal
+  result.mode = modeChoose
 
   var optParser = initOptParser()
   for kind, key, val in optParser.getopt():
@@ -70,14 +70,14 @@ proc parseArguments*: Arguments =
       of ExerciseArgument.short, ExerciseArgument.long:
         result.exercise = some(val)
       of CheckArgument.short, CheckArgument.long:
-        result.action = Action.Check
+        result.action = actCheck
       of DefaultArgument.short, DefaultArgument.long:
         result.mode = parseMode(val)
       of VerbosityArgument.short, VerbosityArgument.long:
         result.verbosity = parseVerbosity(val)
       of HelpArgument.short, HelpArgument.long:
-        result.action = Action.Help
+        result.action = actHelp
       of VersionArgument.short, VersionArgument.long:
-        result.action = Action.Version
+        result.action = actVersion
     else:
       discard

--- a/src/canonicaldatasyncer.nim
+++ b/src/canonicaldatasyncer.nim
@@ -10,13 +10,13 @@ proc main =
   setupLogging(args)
 
   case args.action
-  of Action.Sync:
+  of actSync:
     sync(args)
-  of Action.Check:
+  of actCheck:
     check(args)
-  of Action.Help:
+  of actHelp:
     showHelp()
-  of Action.Version:
+  of actVersion:
     showVersion()
 
 main()

--- a/src/check.nim
+++ b/src/check.nim
@@ -8,14 +8,14 @@ proc check*(args: Arguments) =
 
   for exercise in exercises:
     case exercise.status
-    of ExerciseStatus.OutOfSync:
+    of exOutOfSync:
       logNormal(&"[warn] {exercise.slug}: missing {exercise.tests.missing.len} test cases")
-    of ExerciseStatus.InSync:
+    of exInSync:
       logDetailed(&"[skip] {exercise.slug}: up-to-date")
-    of ExerciseStatus.NoCanonicalData:
+    of exNoCanonicalData:
       logDetailed(&"[skip] {exercise.slug}: does not have canonical data")
 
-  if exercises.anyIt(it.status == ExerciseStatus.OutOfSync):
+  if exercises.anyIt(it.status == exOutOfSync):
     logNormal("[warn] some exercises are missing test cases")
     quit(QuitFailure)
   else:

--- a/src/exercises.nim
+++ b/src/exercises.nim
@@ -13,8 +13,8 @@ type
     excluded*: HashSet[string]
     missing*: HashSet[string]
 
-  ExerciseStatus* {.pure.} = enum
-    OutOfSync, InSync, NoCanonicalData
+  ExerciseStatus* = enum
+    exOutOfSync, exInSync, exNoCanonicalData
 
   Exercise* = object
     slug*: string
@@ -65,11 +65,11 @@ proc findExercises*(args: Arguments): seq[Exercise] =
 
 proc status*(exercise: Exercise): ExerciseStatus =
   if exercise.testCases.len == 0:
-    ExerciseStatus.NoCanonicalData
+    exNoCanonicalData
   elif exercise.tests.missing.len > 0:
-    ExerciseStatus.OutOfSync
+    exOutOfSync
   else:
-    ExerciseStatus.InSync
+    exInSync
 
 proc hasCanonicalData*(exercise: Exercise): bool =
   exercise.testCases.len > 0

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -3,9 +3,9 @@ import arguments
 
 proc levelThreshold(verbosity: Verbosity): Level =
   case verbosity
-  of Verbosity.Quiet: lvlNone
-  of Verbosity.Normal: lvlNotice
-  of Verbosity.Detailed: lvlInfo
+  of verQuiet: lvlNone
+  of verNormal: lvlNotice
+  of verDetailed: lvlInfo
 
 proc setupLogging*(args: Arguments) =
   let consoleLogger = newConsoleLogger(levelThreshold = levelThreshold(args.verbosity), fmtStr = "")


### PR DESCRIPTION
Feel free to suggest changes to the new names - maybe there's something better than the `ex` and `sd` prefixes I used here.

See basically any `enum` in the `nim-lang` repos:
- [Nim/compiler/options.nim](https://github.com/nim-lang/Nim/blob/fe187719abf5fa87e12e4092f87c270234fad25c/compiler/options.nim#L26-L44)
- [Nimble/src/nimblepkg/options.nim](https://github.com/nim-lang/nimble/blob/26167cd3b7671006c8bd38cbef8708431ddf8687/src/nimblepkg/options.nim#L44-L49)
- [Nim/lib/core/macros.nim](https://github.com/nim-lang/Nim/blob/cfba237d142a5ae53d593d69d6e6a560cd21863f/lib/core/macros.nim#L25-L88)
- [Nim/lib/system/io.nim](https://github.com/nim-lang/Nim/blob/cfba237d142a5ae53d593d69d6e6a560cd21863f/lib/system/io.nim#L23-L35)
- [Nim/lib/pure/os.nim](https://github.com/nim-lang/Nim/blob/cfba237d142a5ae53d593d69d6e6a560cd21863f/lib/pure/os.nim#L1586-L1601)
- [Nim/lib/pure/osproc.nim](https://github.com/nim-lang/Nim/blob/cfba237d142a5ae53d593d69d6e6a560cd21863f/lib/pure/osproc.nim#L34-L51)
