### PR TITLE
Build: Reduce binary size

### DIFF
--- a/.github/bin/build
+++ b/.github/bin/build
@@ -7,7 +7,7 @@ case "$OS" in
     nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static'
     ;;
   linux)
-    nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static'
+    nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc
     ;;
   mac)
     nimble build -d:release

--- a/.github/bin/build
+++ b/.github/bin/build
@@ -10,6 +10,6 @@ case "$OS" in
     nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc
     ;;
   mac)
-    nimble build -d:release
+    nimble build -d:release --passC:'-flto'
     ;;
 esac

--- a/.github/bin/build
+++ b/.github/bin/build
@@ -4,12 +4,12 @@ nimble install -d -Y
 
 case "$OS" in
   windows)
-    nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static'
+    nimble build -d:release --opt:size --passC:'-flto' --passL='-s' --passL='-static'
     ;;
   linux)
-    nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc
+    nimble build -d:release --opt:size --passC:'-flto' --passL='-s' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc
     ;;
   mac)
-    nimble build -d:release --passC:'-flto'
+    nimble build -d:release --opt:size --passC:'-flto'
     ;;
 esac

--- a/.github/bin/linux-install-build-tools
+++ b/.github/bin/linux-install-build-tools
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+sudo apt-get install musl-dev musl-tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           nim-version: "1.2.6"
 
+      - name: Install musl on Linux
+        if: matrix.target.os == 'linux'
+        run: ./.github/bin/linux-install-build-tools
+
       - name: Build binary
         shell: bash
         run: ./.github/bin/build


### PR DESCRIPTION
This PR reduces the size of the releases.

Overall: the new Linux, macOS and Windows binaries are respectively 15%, 69% and 77% of their `v0.6.0` size.

Changes:
- Build with musl on Linux
- Build with `-flto` on macOS
- Build with `--opt:size` on all platforms

I have tested on my fork that this configuration builds correctly. See [here](https://github.com/ee7/canonical-data-syncer/releases/tag/build-optimize-release).

But I haven't bumped the version, as @ErikSchierboom is doing that manually at the moment.

Size of the release archive:

|             |   Linux |   macOS | Windows |
|------------ | ------: | ------: | ------: |
| v0.6.0      | 657 KiB | 137 KiB | 115 KiB |
| This commit | 109 KiB |  95 KiB |  90 KiB |
| New / old       |    0.17 |    0.69 |    0.78 |

Size of the binary:

|             |    Linux |   macOS | Windows |
|------------ | -------: | ------: | ------: |
| v0.6.0      | 1458 KiB | 320 KiB | 245 KiB |
| This commit |  222 KiB | 221 KiB | 188 KiB |
| New / old       |     0.15 |    0.69 |    0.77 |