### PR TITLE
Check output to include missing test case descriptions

### DIFF
--- a/src/check.nim
+++ b/src/check.nim
@@ -10,10 +10,9 @@ proc check*(conf: Conf) =
     case exercise.status
     of exOutOfSync:
       logNormal(&"[warn] {exercise.slug}: missing {exercise.tests.missing.len} test cases")
-      let missingCases = exercise.testCases
-        .filterIt(it.uuid in exercise.tests.missing)
-      for testCase in missingCases:
-        logNormal(&"       - {testCase.description} ({testCase.uuid})")
+      for testCase in exercise.testCases:
+        if testCase.uuid in exercise.tests.missing:
+          logNormal(&"       - {testCase.description} ({testCase.uuid})")
     of exInSync:
       logDetailed(&"[skip] {exercise.slug}: up-to-date")
     of exNoCanonicalData:

--- a/src/check.nim
+++ b/src/check.nim
@@ -10,6 +10,10 @@ proc check*(conf: Conf) =
     case exercise.status
     of exOutOfSync:
       logNormal(&"[warn] {exercise.slug}: missing {exercise.tests.missing.len} test cases")
+      let missingCases = exercise.testCases
+        .filterIt(it.uuid in exercise.tests.missing)
+      for testCase in missingCases:
+        logNormal(&"       - {testCase.description} ({testCase.uuid})")
     of exInSync:
       logDetailed(&"[skip] {exercise.slug}: up-to-date")
     of exNoCanonicalData:


### PR DESCRIPTION
Sample output, from the current state of the Tcl track:
```plain
$ ../canonical-data-syncer/canonical_data_syncer -c
Checking exercises...
... git clone output ...
[warn] list-ops: missing 1 test cases
       - empty list to list (e842efed-3bf6-4295-b371-4d67a4fdf19c)
[warn] some exercises are missing test cases
```
