### PR TITLE
Make git clone quiet

### DIFF
--- a/src/probspecs.nim
+++ b/src/probspecs.nim
@@ -27,7 +27,7 @@ proc initProbSpecsRepo: ProbSpecsRepo =
 
 proc clone(repo: ProbSpecsRepo) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {repo.dir}"
-  logDetailed(&"Taking a shallow clone of problem-specifications repo into {repo.dir}")
+  logDetailed(&"Cloning the problem-specifications repo into {repo.dir}...")
   execCmdException(cmd, "Could not clone problem-specifications repo")
 
 proc grainsWorkaround(repo: ProbSpecsRepo) =

--- a/src/probspecs.nim
+++ b/src/probspecs.nim
@@ -1,5 +1,5 @@
 import std/[json, options, os, osproc, sequtils, strformat, strutils]
-import cli
+import cli, logger
 
 type
   ProbSpecsRepoExercise = object
@@ -26,7 +26,8 @@ proc initProbSpecsRepo: ProbSpecsRepo =
   result.dir = probSpecsDir()
 
 proc clone(repo: ProbSpecsRepo) =
-  let cmd = &"git clone --depth 1 https://github.com/exercism/problem-specifications.git {repo.dir}"
+  let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {repo.dir}"
+  logDetailed(&"Taking a shallow clone of problem-specifications repo into {repo.dir}")
   execCmdException(cmd, "Could not clone problem-specifications repo")
 
 proc grainsWorkaround(repo: ProbSpecsRepo) =


### PR DESCRIPTION
Resolving a personal annoyance: get rid of the `git clone` output.

* before this change
    ```bash
    $ ../canonical-data-syncer/canonical_data_syncer -c
    Checking exercises...
    Cloning into '/Users/glennjackman/src/exercism/tcl/.problem-specifications'...
    remote: Enumerating objects: 540, done.
    remote: Counting objects: 100% (540/540), done.
    remote: Compressing objects: 100% (512/512), done.
    remote: Total 540 (delta 27), reused 149 (delta 17), pack-reused 0
    Receiving objects: 100% (540/540), 247.16 KiB | 2.06 MiB/s, done.
    Resolving deltas: 100% (27/27), done.
    [warn] list-ops: missing 1 test cases
    [warn] some exercises are missing test cases
    ```

* after
    ```bash
    $ ../canonical-data-syncer/canonical_data_syncer -c
    Checking exercises...
    [warn] list-ops: missing 1 test cases
    [warn] some exercises are missing test cases

    $ ../canonical-data-syncer/canonical_data_syncer -c -od
    Checking exercises...
    Taking a shallow clone of problem-specifications repo into /Users/glennjackman/src/exercism/tcl/.problem-specifications
    [skip] accumulate: does not have canonical data
    ...
    ```
