### PR TITLE
Fix(cli): Support the syntax of e.g. `-m include`

### DIFF
--- a/canonical_data_syncer.nimble
+++ b/canonical_data_syncer.nimble
@@ -11,3 +11,4 @@ backend       = "c"
 # Dependencies
 requires "nim >= 1.2.6"
 requires "parsetoml"
+requires "cligen"

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -1,4 +1,5 @@
-import std/[options, os, parseopt, strformat, strutils, terminal]
+import std/[options, os, strformat, strutils, terminal]
+import pkg/[cligen/parseopt3]
 
 type
   Action* = enum
@@ -72,7 +73,7 @@ proc prefix(kind: CmdLineKind): string =
   case kind
   of cmdShortOption: "-"
   of cmdLongOption: "--"
-  of cmdArgument, cmdEnd: ""
+  of cmdArgument, cmdEnd, cmdError: ""
 
 proc showErrorForMissingVal(kind: CmdLineKind, key: string, val: string) =
   if val.len == 0:
@@ -145,5 +146,6 @@ proc processCmdLine*: Conf =
         showHelp()
       else:
         showError(&"invalid argument: '{key}'")
-    of cmdEnd:
+    # cmdError can only occur if we pass `requireSep = true` to `getopt`.
+    of cmdEnd, cmdError:
       discard


### PR DESCRIPTION
This PR adds support for separating a short option key from its value with a space (which the help message implied was possible). For example, running either of:
```
    canonical_data_syncer -m include
    canonical_data_syncer -m i
```
would previously produce an error:
```
    Error: '-m' was given without a value
```

This is because the `parseopt` module in Nim's standard library only supports separating a short option key from its value with an equals sign, a colon, or nothing. That is, only these work:
```
    canonical_data_syncer -m=include
    canonical_data_syncer -m:include
    canonical_data_syncer -m=i
    canonical_data_syncer -m:i
    canonical_data_syncer -mi
```

But a long option key and its value _can_ be separated by a space (or an equals sign, or a colon). For example:
```
    canonical_data_syncer --mode=include
    canonical_data_syncer --mode:include
    canonical_data_syncer --mode include
    canonical_data_syncer --mode=i
    canonical_data_syncer --mode:i
    canonical_data_syncer --mode i
```

The simplest fix is to use cligen's `parseopt3` module, which is designed to be API-compatible with `parseopt`. `cligen` is well-known and mature. Now we can support all of the above syntax, at the cost of:
- One extra dependency at compile-time only.
- Increasing the release binary size by about 2% (the Linux release binary is exactly 4 KiB bigger - see [here](https://github.com/ee7/canonical-data-syncer/releases/tag/release-fix-cli-use-parseopt3) for the releases on my fork, using a branch that releases on every push, not a tag).

Fixes: #45