### PR TITLE
Chore: Bump nim from 1.2.6 to 1.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@v1
         with:
-          nim-version: "1.2.6"
+          nim-version: "1.4.0"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/canonical_data_syncer.nimble
+++ b/canonical_data_syncer.nimble
@@ -9,5 +9,5 @@ bin           = @["canonical_data_syncer"]
 backend       = "c"
 
 # Dependencies
-requires "nim >= 1.2.6"
+requires "nim >= 1.4.0"
 requires "parsetoml"


### PR DESCRIPTION
See: https://nim-lang.org/blog/2020/10/16/version-140-released.html

I tested that this builds and releases fine on my fork. See [here](https://github.com/ee7/canonical-data-syncer/releases/tag/release-chore-bump-nim-from-1.2.6-to-1.4.0) (which is a different branch than this PR, configured to create releases on push, not tag).

Closes: #55