### PR TITLE
Refactor(check): Remove duplicate loop

### DIFF
--- a/src/check.nim
+++ b/src/check.nim
@@ -1,14 +1,16 @@
-import std/[sequtils, sets, strformat]
+import std/[sets, strformat]
 import cli, exercises, logger
 
 proc check*(conf: Conf) =
   logNormal("Checking exercises...")
 
   let exercises = findExercises(conf)
+  var hasOutOfSync = false
 
   for exercise in exercises:
     case exercise.status
     of exOutOfSync:
+      hasOutOfSync = true
       logNormal(&"[warn] {exercise.slug}: missing {exercise.tests.missing.len} test cases")
       for testCase in exercise.testCases:
         if testCase.uuid in exercise.tests.missing:
@@ -18,7 +20,7 @@ proc check*(conf: Conf) =
     of exNoCanonicalData:
       logDetailed(&"[skip] {exercise.slug}: does not have canonical data")
 
-  if exercises.anyIt(it.status == exOutOfSync):
+  if hasOutOfSync:
     logNormal("[warn] some exercises are missing test cases")
     quit(QuitFailure)
   else:


### PR DESCRIPTION
This is more efficient, and allows removal of a `sequtils` import.