### PR TITLE
Fix: Show minimal `git clone` output by default

### DIFF
--- a/src/probspecs.nim
+++ b/src/probspecs.nim
@@ -27,7 +27,7 @@ proc initProbSpecsRepo: ProbSpecsRepo =
 
 proc clone(repo: ProbSpecsRepo) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {repo.dir}"
-  logDetailed(&"Cloning the problem-specifications repo into {repo.dir}...")
+  logNormal(&"Cloning the problem-specifications repo into {repo.dir}...")
   execCmdException(cmd, "Could not clone problem-specifications repo")
 
 proc grainsWorkaround(repo: ProbSpecsRepo) =


### PR DESCRIPTION
PR #49 caused the program to produce no output during the `git clone` at the default verbosity setting. It was nice to remove the excessive `git clone` output, but total removal means that the program can appear to hang on a poor internet connection.

This commit makes the situation a little better for that case. In the future, we can try to improve the behaviour further.

Fixes: #52