### PR TITLE
Feature: Add `--probSpecsDir` option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  all_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: linux
+            arch: 64bit
+          - os: mac
+            arch: 64bit
+          - os: windows
+            arch: 64bit
+        include:
+          - target:
+              os: linux
+            builder: ubuntu-18.04
+          - target:
+              os: mac
+            builder: macos-10.15
+          - target:
+              os: windows
+            builder: windows-2019
+
+    name: "${{ matrix.target.os }}-${{ matrix.target.arch }}"
+    runs-on: ${{ matrix.builder }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Nim
+        uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: "1.4.0"
+
+      - name: Install our Nimble dependencies
+        run: nimble -y install --depsOnly
+
+      - name: Run `tests/all_tests.nim`
+        run: nim c --styleCheck:error -r ./tests/all_tests.nim

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -16,9 +16,11 @@ type
     exercise*: Option[string]
     mode*: Mode
     verbosity*: Verbosity
+    probSpecsDir*: Option[string]
 
   Opt = enum
-    optExercise, optCheck, optMode, optVerbosity, optHelp, optVersion
+    optExercise, optCheck, optMode, optVerbosity, optProbSpecsDir,
+    optHelp, optVersion
 
   OptKey = tuple
     short: string
@@ -32,6 +34,7 @@ const
     ("c", "check"),
     ("m", "mode"),
     ("o", "verbosity"),
+    ("p", "probSpecsDir"),
     ("h", "help"),
     ("v", "version"),
   ]
@@ -54,6 +57,7 @@ Options:
   -{optCheck.short}, --{optCheck.long}                  Check if there are missing tests. Doesn't update the tests. Terminates with a non-zero exit code if one or more tests are missing
   -{optMode.short}, --{optMode.long} <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
   -{optVerbosity.short}, --{optVerbosity.long} <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
+  -{optProbSpecsDir.short}, --{optProbSpecsDir.long} <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
   -{optHelp.short}, --{optHelp.long}                   Show this help message and exit
   -{optVersion.short}, --{optVersion.long}                Show this tool's version information and exit"""
 
@@ -63,7 +67,7 @@ proc showVersion =
   echo &"Canonical Data Syncer v{NimblePkgVersion}"
   quit(0)
 
-proc showError(s: string) =
+proc showError*(s: string) =
   stdout.styledWrite(fgRed, "Error: ")
   stdout.write(s)
   stdout.write("\n\n")
@@ -134,6 +138,9 @@ proc processCmdLine*: Conf =
       of optVerbosity.short, optVerbosity.long:
         showErrorForMissingVal(kind, key, val)
         result.verbosity = parseVerbosity(kind, key, val)
+      of optProbSpecsDir.short, optProbSpecsDir.long:
+        showErrorForMissingVal(kind, key, val)
+        result.probSpecsDir = some(val)
       of optHelp.short, optHelp.long:
         showHelp()
       of optVersion.short, optVersion.long:

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,0 +1,3 @@
+import ../tests/[
+  test_probspecs,
+]

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,0 +1,1 @@
+switch("path", "$projectDir/../src")

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -1,0 +1,61 @@
+# This module contains tests for `src/probspecs.nim`
+import std/[json, options, os, osproc, strformat, unittest]
+import cli, probspecs
+
+type
+  ProblemSpecsDir = enum
+    psFresh = "fresh clone"
+    psExisting = "existing dir (simulate the `--probSpecsDir` option)"
+
+proc main =
+  let existingDir = getTempDir() / "test_probspecs_problem-specifications"
+  removeDir(existingDir)
+
+  for ps in ProblemSpecsDir:
+    suite &"findProbSpecsExercises: {ps}":
+      if ps == psExisting:
+        let cmd = "git clone --depth 1 --quiet " &
+                  "https://github.com/exercism/problem-specifications/ " &
+                  existingDir
+        test "can make our own clone for later use as an \"existing dir\"":
+          check:
+            execCmd(cmd) == 0
+
+      let probSpecsDir =
+        case ps
+        of psFresh: none(string)
+        of psExisting: some(existingDir)
+
+      let conf = Conf(probSpecsDir: probSpecsDir)
+      let probSpecsExercises = findProbSpecsExercises(conf)
+
+      test "can return the exercises":
+        check:
+          probSpecsExercises.len >= 116
+
+      test "the first exercise is as expected":
+        let exercise = probSpecsExercises[0]
+
+        check:
+          exercise.slug == "acronym" # The first exercise with canonical data.
+          exercise.testCases.len >= 9 # Tests are never removed.
+
+      test "the first test case is as expected":
+        let firstTestCase = probSpecsExercises[0].testCases[0].json
+        let firstTestCaseExpected = """{
+          "uuid": "1e22cceb-c5e4-4562-9afe-aef07ad1eaf4",
+          "description": "basic",
+          "property": "abbreviate",
+          "input": {
+            "phrase": "Portable Network Graphics"
+          },
+          "expected": "PNG"
+        }""".parseJson()
+
+        check:
+          firstTestCase == firstTestCaseExpected
+
+  removeDir(existingDir)
+
+main()
+{.used.}


### PR DESCRIPTION
See the commit messages for more information - the commits are atomic.

Some things like the `git` error messages could probably be cleaned up a bit, and there's some obvious tests to add, but it should be reasonably robust. I think the implementation here is quite strict. Let me know if I missed any edge cases.

WIP:
- [X] Don't `checkout` or `merge`, even if the working directory is clean.
- [X] Try not to assume things about the remotes in the given directory.

Closes: https://github.com/exercism/canonical-data-syncer/issues/47

