### PR TITLE
Feature: Add `--offline` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Options:
   -m, --mode <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
   -v, --verbosity <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
   -p, --probSpecsDir <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
+  -o, --offline                Do not check that the directory specified by `-p, --probSpecsDir` is up-to-date
   -h, --help                   Show this help message and exit
   --version                    Show this tool's version information and exit
 ```

--- a/src/probspecs.nim
+++ b/src/probspecs.nim
@@ -175,7 +175,8 @@ proc validate(probSpecsRepo: ProbSpecsRepo) =
 proc findProbSpecsExercises*(conf: Conf): seq[ProbSpecsExercise] =
   if conf.probSpecsDir.isSome():
     let probSpecsRepo = ProbSpecsRepo(dir: conf.probSpecsDir.get())
-    probSpecsRepo.validate()
+    if not conf.offline:
+      probSpecsRepo.validate()
     result = probSpecsRepo.findProbSpecsExercises(conf)
   else:
     let probSpecsRepo = initProbSpecsRepo()


### PR DESCRIPTION
Motivations:
1. It allows us to establish an initial state for a `problem-specifications` directory, which means we can do black-box testing of the release binary. That is, we wouldn't be able to assert the exact outcome after running the binary if the `problem-specifications` directory is always different at the start of testing.
1. Maintainers can still use the tool even when they have no internet connection, or a very bad one.
1. Maintainers might want a "trust me, I know what I'm doing" switch so that they don't have to wait for a `git fetch`, knowing that `problem-specifications` doesn't update that often.
1. Developers of `canonical_data_syncer` can also benefit from 3 and 4.

Decisions:
- Implement this as an `--offline` flag, rather than an `--online` flag. The current implementation is seen as harder to misuse.

Closes: #66