### PR TITLE
Feature: Add `--trackDir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options for uuid:
 Global options:
   -h, --help                   Show this help message and exit
       --version                Show this tool's version information and exit
+  -t, --track-dir <dir>        Specify a track directory to use instead of the current directory
   -v, --verbosity <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
 ```
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -217,9 +217,11 @@ func initAction*(actionKind: ActionKind, probSpecsDir = ""): Action =
   of actUuid:
     Action(kind: actionKind, num: 1)
 
-func initConf*(action = initAction(actNil), verbosity = verNormal): Conf =
+func initConf*(action = initAction(actNil), trackDir = getCurrentDir(),
+               verbosity = verNormal): Conf =
   result = Conf(
     action: action,
+    trackDir: trackDir,
     verbosity: verbosity,
   )
 
@@ -289,7 +291,7 @@ proc handleArgument(conf: var Conf; kind: CmdLineKind; key: string) =
   if conf.action.kind == actNil:
     let actionKind = parseActionKind(key)
     let action = initAction(actionKind)
-    conf = initConf(action, conf.verbosity)
+    conf = initConf(action, conf.trackDir, conf.verbosity)
   else:
     showError(&"invalid argument for command '{conf.action.kind}': '{key}'")
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -35,11 +35,13 @@ type
 
   Conf* = object
     action*: Action
+    trackDir*: string
     verbosity*: Verbosity
 
   Opt = enum
     optHelp = "help"
     optVersion = "version"
+    optTrackDir = "trackDir"
     optVerbosity = "verbosity"
     optSyncExercise = "exercise"
     optSyncCheck = "check"
@@ -110,6 +112,7 @@ func genHelpText: string =
     for opt in Opt:
       let paramName =
         case opt
+        of optTrackDir: "dir"
         of optVerbosity: "verbosity"
         of optSyncExercise: "slug"
         of optSyncMode: "mode"
@@ -127,6 +130,7 @@ func genHelpText: string =
   const descriptions: array[Opt, string] = [
     optHelp: "Show this help message and exit",
     optVersion: "Show this tool's version information and exit",
+    optTrackDir: "Specify a track directory to use instead of the current directory",
     optVerbosity: &"The verbosity of output. {allowedValues(Verbosity)}",
     optSyncExercise: "Only sync this exercise",
     optSyncCheck: "Terminates with a non-zero exit code if one or more tests " &
@@ -310,6 +314,8 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
     showHelp()
   of optVersion:
     showVersion()
+  of optTrackDir:
+    setGlobalOpt(trackDir, val)
   of optVerbosity:
     setGlobalOpt(verbosity, parseVal[Verbosity](kind, key, val))
   else:

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -75,8 +75,8 @@ proc status*(exercise: Exercise): ExerciseStatus =
 proc hasCanonicalData*(exercise: Exercise): bool =
   exercise.testCases.len > 0
 
-proc testsFile(exercise: Exercise): string =
-  getCurrentDir() / "exercises" / exercise.slug / ".meta" / "tests.toml"
+proc testsFile(exercise: Exercise, trackDir: string): string =
+  trackDir / "exercises" / exercise.slug / ".meta" / "tests.toml"
 
 proc toToml(exercise: Exercise): string =
   result.add("[canonical-tests]\n")
@@ -89,8 +89,8 @@ proc toToml(exercise: Exercise): string =
     result.add(&"\n# {testCase.description}")
     result.add(&"\n\"{testCase.uuid}\" = {isIncluded}\n")
 
-proc writeTestsToml*(exercise: Exercise) =
-  let testsPath = testsFile(exercise)
+proc writeTestsToml*(exercise: Exercise, trackDir: string) =
+  let testsPath = testsFile(exercise, trackDir)
   createDir(testsPath.parentDir())
 
   let contents = toToml(exercise)

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -83,5 +83,9 @@ proc findTrackExercises(repo: TrackRepo, conf: Conf): seq[TrackExercise] =
       result.add(newTrackExercise(repoExercise))
 
 proc findTrackExercises*(conf: Conf): seq[TrackExercise] =
-  let trackRepo = newTrackRepo()
+  let trackRepo =
+    if conf.trackDir.len > 0:
+      TrackRepo(dir: conf.trackDir)
+    else:
+      newTrackRepo()
   trackRepo.findTrackExercises(conf)

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -24,9 +24,6 @@ type
     tests*: TrackExerciseTests
     repoExercise: TrackRepoExercise
 
-proc newTrackRepo: TrackRepo =
-  result.dir = getCurrentDir()
-
 proc configJsonFile(repo: TrackRepo): string =
   repo.dir / "config.json"
 
@@ -83,9 +80,5 @@ proc findTrackExercises(repo: TrackRepo, conf: Conf): seq[TrackExercise] =
       result.add(newTrackExercise(repoExercise))
 
 proc findTrackExercises*(conf: Conf): seq[TrackExercise] =
-  let trackRepo =
-    if conf.trackDir.len > 0:
-      TrackRepo(dir: conf.trackDir)
-    else:
-      newTrackRepo()
+  let trackRepo = TrackRepo(dir: conf.trackDir)
   trackRepo.findTrackExercises(conf)


### PR DESCRIPTION
With this PR, we can now establish a beginning state by specifying:
- a track directory
- a problem-specifications directory
- the offline mode

This allows us to start doing black-box testing of the release binary, running something like:
```
    configlet sync --track-dir /tmp/python --prob-specs-dir /tmp/my_prob_specs --offline
```
and then asserting that the changes made are as expected.

Closes: #50

WIP: 
- [X] Rebase this PR on `master` and reflect recent changes (e.g. `--trackDir` -> `--track-dir`)
- [X] In `sync` mode, make it write to the given `-t, --trackDir`, rather than relative to the current directory.
- [X] Merge #134 and rebase this PR on top.
- [x] Address review comments

Let's add tests in a later PR. We can leave `-t, --track-dir` undocumented in the first `configlet` releases if we feel it isn't tested well enough. 

Note that `--track-dir` is implemented as a global option, not an option for `sync` - the option will also be useful for e.g. `lint`.

This feature makes it much more ergonomic to implement tests for `lint`.
