### PR TITLE
Fix(cli): Parse options insensitive to style

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -117,6 +117,20 @@ proc initConf: Conf =
     verbosity: verNormal,
   )
 
+func normalizeOption(s: string): string =
+  ## Returns the string `s`, but converted to lowercase and without '_' or '-'.
+  result = newString(s.len)
+  var i = 0
+  for c in s:
+    if c in {'A'..'Z'}:
+      result[i] = toLowerAscii(c)
+      inc i
+    elif c notin {'_', '-'}:
+      result[i] = c
+      inc i
+  if i != s.len:
+    setLen(result, i)
+
 proc processCmdLine*: Conf =
   result = initConf()
 
@@ -129,7 +143,7 @@ proc processCmdLine*: Conf =
   for kind, key, val in getopt(shortNoVal = shortNoVal, longNoVal = longNoVal):
     case kind
     of cmdLongOption, cmdShortOption:
-      case key
+      case key.normalizeOption()
       of optExercise.short, optExercise.long:
         showErrorForMissingVal(kind, key, val)
         result.exercise = some(val)
@@ -141,7 +155,7 @@ proc processCmdLine*: Conf =
       of optVerbosity.short, optVerbosity.long:
         showErrorForMissingVal(kind, key, val)
         result.verbosity = parseVerbosity(kind, key, val)
-      of optProbSpecsDir.short, optProbSpecsDir.long:
+      of optProbSpecsDir.short, optProbSpecsDir.long.toLowerAscii():
         showErrorForMissingVal(kind, key, val)
         result.probSpecsDir = some(val)
       of optOffline.short, optOffline.long:


### PR DESCRIPTION
Most importantly, these previously invalid options are now accepted:
```
    --probspecsdir
    --prob-specs-dir
    --prob_specs_dir
```
Before this PR, we could only use:
```
    --probSpecsDir
```

That is: `--kebab-case` is now supported, even if that fact or `--prob-specs-dir` itself aren't shown in the `--help` message yet.

Note that we already had case-insensitive parsing for:
  - the values for `mode`
  - the values for `verbosity`
  - arguments (we support `canonical_data_syncer HELP`)

Fixes: #79