### PR TITLE
Fix(cli): Align long options in help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Options:
   -p, --probSpecsDir <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
   -o, --offline                Do not check that the directory specified by `-p, --probSpecsDir` is up-to-date
   -h, --help                   Show this help message and exit
-  --version                    Show this tool's version information and exit
+      --version                Show this tool's version information and exit
 ```
 
 Running the application will prompt the user to choose whether to include or exclude missing tests. It will update the `tests.toml` file accordingly. If you only want a quick check, you can use the `--check` option.

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -62,7 +62,7 @@ Options:
   -{optProbSpecsDir.short}, --{optProbSpecsDir.long} <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
   -{optOffline.short}, --{optOffline.long}                Do not check that the directory specified by `-p, --probSpecsDir` is up-to-date
   -{optHelp.short}, --{optHelp.long}                   Show this help message and exit
-  --{optVersion.long}                    Show this tool's version information and exit"""
+      --{optVersion.long}                Show this tool's version information and exit"""
 
   quit(0)
 


### PR DESCRIPTION
I think this looks nicer, and a lot of my CLI tools do it too.