### PR TITLE
Refactor(cli): Reduce duplication

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -6,10 +6,14 @@ type
     actSync, actCheck
 
   Mode* = enum
-    modeChoose, modeInclude, modeExclude
+    modeChoose = "choose"
+    modeInclude = "include"
+    modeExclude = "exclude"
 
   Verbosity* = enum
-    verQuiet, verNormal, verDetailed
+    verQuiet = "quiet"
+    verNormal = "normal"
+    verDetailed = "detailed"
 
   Conf* = object
     action*: Action
@@ -50,6 +54,19 @@ func list(opt: Opt): string =
   else:
     &"-{short[opt]}, --{$opt}"
 
+func first(s: string): string =
+  # Returns the first character of `s` as a string.
+  result = newString(1)
+  result[0] = s[0]
+
+func allowedValues(T: typedesc[enum]): string =
+  ## Returns a string that describes the allowed values for an enum `T`.
+  result = "Allowed values: "
+  for val in T:
+    result &= &"{($val)[0]}"
+    result &= &"[{($val)[1 .. ^1]}], "
+  setLen(result, result.len - 2)
+
 proc showHelp =
   let applicationName = extractFilename(getAppFilename())
 
@@ -58,8 +75,8 @@ proc showHelp =
 Options:
   {list(optExercise)} <slug>        Only sync this exercise
   {list(optCheck)}                  Terminates with a non-zero exit code if one or more tests are missing. Doesn't update the tests
-  {list(optMode)} <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
-  {list(optVerbosity)} <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
+  {list(optMode)} <mode>            What to do with missing test cases. {allowedValues(Mode)}
+  {list(optVerbosity)} <verbosity>  The verbosity of output. {allowedValues(Verbosity)}
   {list(optProbSpecsDir)} <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
   {list(optOffline)}                Do not check that the directory specified by `{list(optProbSpecsDir)}` is up-to-date
   {list(optHelp)}                   Show this help message and exit
@@ -85,22 +102,22 @@ proc prefix(kind: CmdLineKind): string =
 
 proc parseMode(kind: CmdLineKind, key: string, val: string): Mode =
   case val.toLowerAscii
-  of "c", "choose":
+  of first($modeChoose), $modeChoose:
     result = modeChoose
-  of "i", "include":
+  of first($modeInclude), $modeInclude:
     result = modeInclude
-  of "e", "exclude":
+  of first($modeExclude), $modeExclude:
     result = modeExclude
   else:
     showError(&"invalid value for '{kind.prefix}{key}': '{val}'")
 
 proc parseVerbosity(kind: CmdLineKind, key: string, val: string): Verbosity =
   case val.toLowerAscii
-  of "q", "quiet":
+  of first($verQuiet), $verQuiet:
     result = verQuiet
-  of "n", "normal":
+  of first($verNormal), $verNormal:
     result = verNormal
-  of "d", "detailed":
+  of first($verDetailed), $verDetailed:
     result = verDetailed
   else:
     showError(&"invalid value for '{kind.prefix}{key}': '{val}'")

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -49,20 +49,26 @@ func short(opt: Opt): string =
 func long(opt: Opt): string =
   result = optKeys[opt].long
 
+func list(opt: Opt): string =
+  if opt.short == "_":
+    &"    --{opt.long}"
+  else:
+    &"-{opt.short}, --{opt.long}"
+
 proc showHelp =
   let applicationName = extractFilename(getAppFilename())
 
   echo &"""Usage: {applicationName} [options]
 
 Options:
-  -{optExercise.short}, --{optExercise.long} <slug>        Only sync this exercise
-  -{optCheck.short}, --{optCheck.long}                  Terminates with a non-zero exit code if one or more tests are missing. Doesn't update the tests
-  -{optMode.short}, --{optMode.long} <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
-  -{optVerbosity.short}, --{optVerbosity.long} <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
-  -{optProbSpecsDir.short}, --{optProbSpecsDir.long} <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
-  -{optOffline.short}, --{optOffline.long}                Do not check that the directory specified by `-p, --probSpecsDir` is up-to-date
-  -{optHelp.short}, --{optHelp.long}                   Show this help message and exit
-      --{optVersion.long}                Show this tool's version information and exit"""
+  {list(optExercise)} <slug>        Only sync this exercise
+  {list(optCheck)}                  Terminates with a non-zero exit code if one or more tests are missing. Doesn't update the tests
+  {list(optMode)} <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
+  {list(optVerbosity)} <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
+  {list(optProbSpecsDir)} <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
+  {list(optOffline)}                Do not check that the directory specified by `{list(optProbSpecsDir)}` is up-to-date
+  {list(optHelp)}                   Show this help message and exit
+  {list(optVersion)}                Show this tool's version information and exit"""
 
   quit(0)
 
@@ -177,4 +183,4 @@ proc processCmdLine*: Conf =
       discard
 
   if result.offline and result.probSpecsDir.isNone():
-    showError("'-o, --offline' was given without passing '-p, --probSpecsDir'")
+    showError(&"'{list(optOffline)}' was given without passing '{list(optProbSpecsDir)}'")

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -6,7 +6,7 @@ type
     actSync, actCheck
 
   Mode* = enum
-    modeChoose, modeIncludeMissing, modeExcludeMissing
+    modeChoose, modeInclude, modeExclude
 
   Verbosity* = enum
     verQuiet, verNormal, verDetailed
@@ -88,9 +88,9 @@ proc parseMode(kind: CmdLineKind, key: string, val: string): Mode =
   of "c", "choose":
     result = modeChoose
   of "i", "include":
-    result = modeIncludeMissing
+    result = modeInclude
   of "e", "exclude":
-    result = modeExcludeMissing
+    result = modeExclude
   else:
     showError(&"invalid value for '{kind.prefix}{key}': '{val}'")
 

--- a/src/sync.nim
+++ b/src/sync.nim
@@ -56,9 +56,9 @@ proc chooseSyncDecision(testCase: ExerciseTestCase): SyncDecision =
 
 proc syncDecision(testCase: ExerciseTestCase, mode: Mode): SyncDecision =
   case mode
-  of modeIncludeMissing:
+  of modeInclude:
     sdIncludeTest
-  of modeExcludeMissing:
+  of modeExclude:
     sdExcludeTest
   of modeChoose:
     chooseSyncDecision(testCase)
@@ -67,9 +67,9 @@ proc sync(exercise: Exercise, mode: Mode): Exercise =
   result = exercise
 
   case mode
-  of modeIncludeMissing:
+  of modeInclude:
     logNormal(&"[info] {exercise.slug}: included {exercise.tests.missing.len} missing test cases")
-  of modeExcludeMissing:
+  of modeExclude:
     logNormal(&"[info] {exercise.slug}: excluded {exercise.tests.missing.len} missing test cases")
   of modeChoose:
     logNormal(&"[warn] {exercise.slug}: missing {exercise.tests.missing.len} test cases")


### PR DESCRIPTION
~To-do~
- [x] Merge #84 (the commit is included in this PR)
- [x] Merge #85 (the commit is included in this PR)
- [x] Rebase this PR on `master`

This PR reduces the code duplication in `cli.nim`.

The commits are atomic - please review individually. But they can be squashed before merging, if we prefer, given that they work towards the same goal.

Motivations:
- We don't need separate `parseMode` and `parseVerbosity` functions -
  we can just have a generic `parseValue` proc, which is easily
  extended if we ever add more options that have values.
- There should be a single source of truth for the string values of
  options/values.
- This refactoring makes it easier to add support for unambiguous
  abbreviations of options.
- We don't need to specify all the short options, just the short options
  that we don't want to have.