### PR TITLE
Refactor(cli): Be explicit in `initConf`

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -101,6 +101,8 @@ proc initConf: Conf =
     exercise: none(string),
     mode: modeChoose,
     verbosity: verNormal,
+    probSpecsDir: none(string),
+    offline: false,
   )
 
 func normalizeOption(s: string): string =


### PR DESCRIPTION
This proc already didn't include `probSpecsDir`, and `offline`, so let's only set the value that's different from the default (which is `verbosity` - the default is `verQuiet` since we list it first).