### PR TITLE
Refactor: Change `Action` to bool `check`

### DIFF
--- a/src/canonical_data_syncer.nim
+++ b/src/canonical_data_syncer.nim
@@ -9,10 +9,9 @@ proc main =
 
   setupLogging(conf)
 
-  case conf.action
-  of actSync:
-    sync(conf)
-  of actCheck:
+  if conf.check:
     check(conf)
+  else:
+    sync(conf)
 
 main()

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -2,9 +2,6 @@ import std/[options, os, strformat, strutils, terminal]
 import pkg/[cligen/parseopt3]
 
 type
-  Action* = enum
-    actSync, actCheck
-
   Mode* = enum
     modeChoose = "choose"
     modeInclude = "include"
@@ -16,8 +13,8 @@ type
     verDetailed = "detailed"
 
   Conf* = object
-    action*: Action
     exercise*: Option[string]
+    check*: bool
     mode*: Mode
     verbosity*: Verbosity
     probSpecsDir*: Option[string]
@@ -110,8 +107,8 @@ proc prefix(kind: CmdLineKind): string =
 
 proc initConf: Conf =
   result = Conf(
-    action: actSync,
     exercise: none(string),
+    check: false,
     mode: modeChoose,
     verbosity: verNormal,
     probSpecsDir: none(string),
@@ -179,7 +176,7 @@ proc processCmdLine*: Conf =
       of optExercise:
         result.exercise = some(val)
       of optCheck:
-        result.action = actCheck
+        result.check = true
       of optMode:
         result.mode = parseVal[Mode](kind, key, val)
       of optVerbosity:


### PR DESCRIPTION
The option for using the check-only mode is `--check`, rather than `--action=check` so let's reflect that internally.

To-do:
- [x] Merge https://github.com/exercism/canonical-data-syncer/pull/88 then rebase this PR on `master`