### PR TITLE
Refactor: Convert some `Option[string]` to `string`

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -1,4 +1,4 @@
-import std/[options, os, strformat, strutils, terminal]
+import std/[os, strformat, strutils, terminal]
 import pkg/[cligen/parseopt3]
 
 type
@@ -13,11 +13,11 @@ type
     verDetailed = "detailed"
 
   Conf* = object
-    exercise*: Option[string]
+    exercise*: string
     check*: bool
     mode*: Mode
     verbosity*: Verbosity
-    probSpecsDir*: Option[string]
+    probSpecsDir*: string
     offline*: bool
 
   Opt = enum
@@ -107,11 +107,11 @@ proc prefix(kind: CmdLineKind): string =
 
 proc initConf: Conf =
   result = Conf(
-    exercise: none(string),
+    exercise: "",
     check: false,
     mode: modeChoose,
     verbosity: verNormal,
-    probSpecsDir: none(string),
+    probSpecsDir: "",
     offline: false,
   )
 
@@ -174,7 +174,7 @@ proc processCmdLine*: Conf =
     of cmdLongOption, cmdShortOption:
       case parseOption(kind, key, val)
       of optExercise:
-        result.exercise = some(val)
+        result.exercise = val
       of optCheck:
         result.check = true
       of optMode:
@@ -182,7 +182,7 @@ proc processCmdLine*: Conf =
       of optVerbosity:
         result.verbosity = parseVal[Verbosity](kind, key, val)
       of optProbSpecsDir:
-        result.probSpecsDir = some(val)
+        result.probSpecsDir = val
       of optOffline:
         result.offline = true
       of optHelp:
@@ -199,5 +199,5 @@ proc processCmdLine*: Conf =
     of cmdEnd, cmdError:
       discard
 
-  if result.offline and result.probSpecsDir.isNone():
+  if result.offline and result.probSpecsDir.len == 0:
     showError(&"'{list(optOffline)}' was given without passing '{list(optProbSpecsDir)}'")

--- a/src/probspecs.nim
+++ b/src/probspecs.nim
@@ -1,4 +1,4 @@
-import std/[json, options, os, osproc, sequtils, strformat, strscans, strutils]
+import std/[json, os, osproc, sequtils, strformat, strscans, strutils]
 import cli, logger
 
 type
@@ -99,7 +99,7 @@ proc initProbSpecsExercise(repoExercise: ProbSpecsRepoExercise): ProbSpecsExerci
 
 proc findProbSpecsExercises(repo: ProbSpecsRepo, conf: Conf): seq[ProbSpecsExercise] =
   for repoExercise in repo.exercisesWithCanonicalData():
-    if conf.exercise.isNone or conf.exercise.get() == repoExercise.slug:
+    if conf.exercise.len == 0 or conf.exercise == repoExercise.slug:
       result.add(initProbSpecsExercise(repoExercise))
 
 template withDir(dir: string; body: untyped): untyped =
@@ -175,8 +175,8 @@ proc validate(probSpecsRepo: ProbSpecsRepo) =
                 &"up-to-date: '{probSpecsDir}'")
 
 proc findProbSpecsExercises*(conf: Conf): seq[ProbSpecsExercise] =
-  if conf.probSpecsDir.isSome():
-    let probSpecsRepo = ProbSpecsRepo(dir: conf.probSpecsDir.get())
+  if conf.probSpecsDir.len > 0:
+    let probSpecsRepo = ProbSpecsRepo(dir: conf.probSpecsDir)
     if not conf.offline:
       probSpecsRepo.validate()
     result = probSpecsRepo.findProbSpecsExercises(conf)

--- a/src/tracks.nim
+++ b/src/tracks.nim
@@ -1,4 +1,4 @@
-import std/[json, options, os, sets]
+import std/[json, os, sets]
 import pkg/parsetoml
 import cli
 
@@ -79,7 +79,7 @@ proc newTrackExercise(exercise: TrackRepoExercise): TrackExercise =
 
 proc findTrackExercises(repo: TrackRepo, conf: Conf): seq[TrackExercise] =
   for repoExercise in repo.exercises:
-    if conf.exercise.isNone or conf.exercise.get() == repoExercise.slug:
+    if conf.exercise.len == 0 or conf.exercise == repoExercise.slug:
       result.add(newTrackExercise(repoExercise))
 
 proc findTrackExercises*(conf: Conf): seq[TrackExercise] =

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -1,5 +1,5 @@
 # This module contains tests for `src/probspecs.nim`
-import std/[json, options, os, osproc, strformat, unittest]
+import std/[json, os, osproc, strformat, unittest]
 import cli, probspecs
 
 type
@@ -23,8 +23,8 @@ proc main =
 
       let probSpecsDir =
         case ps
-        of psFresh: none(string)
-        of psExisting: some(existingDir)
+        of psFresh: ""
+        of psExisting: existingDir
 
       let conf = Conf(probSpecsDir: probSpecsDir)
       let probSpecsExercises = findProbSpecsExercises(conf)


### PR DESCRIPTION
There isn't much reason to use `Option[string]` for `exercise` and `probSpecsDir` - we can just test whether the string is empty.

This also allows us to consider setting the default value of `probSpecsDir` to `.problem-specifications` in the future, which better models the current behaviour.  

Note that (both before and after this commit) if we run any of:
```
canonical_data_syncer -p=
canonical_data_syncer -p
canonical_data_syncer -e=
canonical_data_syncer -e
```

Then we see an error message like:
```
Error: '-p' was given without a value
```