### PR TITLE
Fix(cli): Display long options in kebab-case form

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Options:
   -c, --check                  Terminates with a non-zero exit code if one or more tests are missing. Doesn't update the tests
   -m, --mode <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
   -v, --verbosity <verbosity>  The verbosity of output. Allowed values: q[uiet], n[ormal], d[etailed]
-  -p, --probSpecsDir <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
-  -o, --offline                Do not check that the directory specified by `-p, --probSpecsDir` is up-to-date
+  -p, --prob-specs-dir <dir>   Use this `problem-specifications` directory, rather than cloning temporarily
+  -o, --offline                Do not check that the directory specified by `-p, --prob-specs-dir` is up-to-date
   -h, --help                   Show this help message and exit
       --version                Show this tool's version information and exit
 ```

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -58,11 +58,22 @@ func generateNoVals: tuple[shortNoVal: set[char], longNoVal: seq[string]] =
 const
   (shortNoVal, longNoVal) = generateNoVals()
 
+func camelToKebab(s: string): string =
+  ## Converts the string `s` to lowercase, adding a `-` before each previously
+  ## uppercase letter.
+  result = newStringOfCap(s.len + 2)
+  for c in s:
+    if c in {'A'..'Z'}:
+      result &= '-'
+      result &= toLowerAscii(c)
+    else:
+      result &= c
+
 func list(opt: Opt): string =
   if short[opt] == '_':
-    &"    --{$opt}"
+    &"    --{camelToKebab($opt)}"
   else:
-    &"-{short[opt]}, --{$opt}"
+    &"-{short[opt]}, --{camelToKebab($opt)}"
 
 func allowedValues(T: typedesc[enum]): string =
   ## Returns a string that describes the allowed values for an enum `T`.
@@ -82,7 +93,7 @@ Options:
   {list(optCheck)}                  Terminates with a non-zero exit code if one or more tests are missing. Doesn't update the tests
   {list(optMode)} <mode>            What to do with missing test cases. {allowedValues(Mode)}
   {list(optVerbosity)} <verbosity>  The verbosity of output. {allowedValues(Verbosity)}
-  {list(optProbSpecsDir)} <dir>     Use this `problem-specifications` directory, rather than cloning temporarily
+  {list(optProbSpecsDir)} <dir>   Use this `problem-specifications` directory, rather than cloning temporarily
   {list(optOffline)}                Do not check that the directory specified by `{list(optProbSpecsDir)}` is up-to-date
   {list(optHelp)}                   Show this help message and exit
   {list(optVersion)}                Show this tool's version information and exit"""

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -5,7 +5,7 @@ import cli, probspecs
 type
   ProblemSpecsDir = enum
     psFresh = "fresh clone"
-    psExisting = "existing dir (simulate the `--probSpecsDir` option)"
+    psExisting = "existing dir (simulate the `--prob-specs-dir` option)"
 
 proc main =
   let existingDir = getTempDir() / "test_probspecs_problem-specifications"


### PR DESCRIPTION
It's more common to see kebab-case in command-line tools.

This commit only affects how the options are printed; we already parse user-provided options by normalizing for case, `-` and `_`.

Closes: #80