### PR TITLE
Test: Add initial tests for the binary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,19 @@ jobs:
         with:
           nim-version: "1.4.0"
 
+      - name: Install musl on Linux
+        if: matrix.target.os == 'linux'
+        run: ./.github/bin/linux-install-build-tools
+
       - name: Install our Nimble dependencies
         run: nimble -y install --depsOnly
+
+      - name: Build binary
+        shell: bash
+        run: ./.github/bin/build
+        env:
+          OS: ${{ matrix.target.os }}
+          ARCH: ${{ matrix.target.arch }}
 
       - name: Run `tests/all_tests.nim`
         run: nim c --styleCheck:error -r ./tests/all_tests.nim

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,3 +1,4 @@
 import "."/[
+  test_binary,
   test_probspecs,
 ]

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1,0 +1,82 @@
+import std/[os, osproc, strformat, strscans, strutils, unittest]
+
+const
+  binaryExt =
+    when defined(windows): ".exe"
+    else: ""
+  binaryName = "canonical_data_syncer" & binaryExt
+
+proc main =
+  let repoRootDir = getAppDir().parentDir()
+  let binaryPath = repoRootDir / binaryName
+  const helpStart = &"Usage: {binaryName} [options]"
+
+  suite "help as an argument":
+    test "help":
+      let (outp, _) = execCmdEx(&"{binaryPath} help")
+      check:
+        outp.startsWith(helpStart)
+
+  suite "help as an option":
+    for goodHelp in ["-h", "--help"]:
+      test goodHelp:
+        let (outp, _) = execCmdEx(&"{binaryPath} {goodHelp}")
+        check:
+          outp.startsWith(helpStart)
+
+  suite "help via normalization":
+    for goodHelp in ["-H", "--HELP", "--hElP", "--HeLp", "--H--e-L__p"]:
+      test goodHelp:
+        let (outp, _) = execCmdEx(&"{binaryPath} {goodHelp}")
+        check:
+          outp.startsWith(helpStart)
+
+  suite "help is always printed if present":
+    for goodHelp in ["--help --check", "-ch", "-hc", "-ho", "-oh"]:
+      test goodHelp:
+        let (outp, _) = execCmdEx(&"{binaryPath} {goodHelp}")
+        check:
+          outp.startsWith(helpStart)
+
+  suite "invalid argument":
+    for badArg in ["h", "halp", "-", "_", "__", "foo", "FOO", "f-o-o", "f_o_o",
+                   "f--o"]:
+      test badArg:
+        let (outp, _) = execCmdEx(&"{binaryPath} {badArg}")
+        check:
+          outp.contains(&"invalid argument: '{badArg}'")
+
+  suite "invalid option":
+    for badOption in ["--halp", "--checkk"]:
+      test badOption:
+        let (outp, _) = execCmdEx(&"{binaryPath} {badOption}")
+        check:
+          outp.contains(&"invalid option: '{badOption}'")
+
+  suite "invalid value":
+    for (option, badValue) in [("--mode", "foo"), ("--mode", "f"),
+                               ("-m", "foo"), ("-m", "f"),
+                               ("-m", "--check"), ("-m", "-c"),
+                               ("-m", "-mc"), ("-m", "--mode")]:
+      for sep in [" ", "=", ":"]:
+        test &"{option}{sep}{badValue}":
+          let (outp, _) = execCmdEx(&"{binaryPath} {option}{sep}{badValue}")
+          check:
+            outp.contains(&"invalid value for '{option}': '{badValue}'")
+
+  suite "version":
+    test "--version":
+      let (outp, _) = execCmdEx(&"{binaryPath} --version")
+      var major, minor, patch: int
+      check:
+        outp.scanf("Canonical Data Syncer v$i.$i.$i$s$.", major, minor, patch)
+
+  suite "offline":
+    for offline in ["--offline", "-o"]:
+      test &"requires --prob-specs-dir: {offline}":
+        let (outp, _) = execCmdEx(&"{binaryPath} {offline}")
+        check:
+          outp.contains("'-o, --offline' was given without passing '-p, --prob-specs-dir'")
+
+main()
+{.used.}


### PR DESCRIPTION
For now, this just tests some of the CLI parsing.

We should find a better way to structure the tests, because we want:
- a failing test of the binary should block a release (that doesn't happen with this PR)
- tests of the binary should run on `push` and `pull_request` (we can't just add it to `build.yml` without modification because that runs only on tagging)

https://github.com/exercism/canonical-data-syncer/blob/2ebc4f6d73adeeef4643a9e5b88a948962cf1e25/.github/workflows/build.yml#L3-L6

Maybe something like:
- move `test_binary.nim` out of `all_tests.nim`
- rename `all_tests.nim`
- make the release part of the `build.yml` workflow a separate job that depends on a testing job that runs on `push` and `pull_request`