### PR TITLE
Refactor: Use per-command src subdirectories

### DIFF
--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,5 +1,5 @@
-import std/posix
-import check, cli, logger, sync
+import std/[posix]
+import "."/[cli, logger, sync/check, sync/sync]
 
 proc main =
   onSignal(SIGTERM):

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -1,5 +1,5 @@
-import std/logging
-import cli
+import std/[logging]
+import "."/[cli]
 
 proc levelThreshold(verbosity: Verbosity): Level =
   case verbosity

--- a/src/sync/check.nim
+++ b/src/sync/check.nim
@@ -1,5 +1,6 @@
 import std/[sets, strformat]
-import cli, exercises, logger
+import ".."/[cli, logger]
+import "."/[exercises]
 
 proc check*(conf: Conf) =
   logNormal("Checking exercises...")

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -1,5 +1,6 @@
 import std/[algorithm, json, options, os, sequtils, sets, strformat, tables]
-import cli, probspecs, tracks
+import ".."/[cli]
+import "."/[probspecs, tracks]
 
 type
   ExerciseTestCase* = ref object

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -1,5 +1,5 @@
 import std/[json, os, osproc, sequtils, strformat, strscans, strutils]
-import cli, logger
+import ".."/[cli, logger]
 
 type
   ProbSpecsRepoExercise = object

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -1,5 +1,6 @@
 import std/[json, options, sequtils, sets, strformat, strutils]
-import cli, exercises, logger
+import ".."/[cli, logger]
+import "."/[exercises]
 
 type
   SyncDecision = enum

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -1,6 +1,6 @@
 import std/[json, os, sets]
-import pkg/parsetoml
-import cli
+import pkg/[parsetoml]
+import ".."/[cli]
 
 type
   ConfigJsonExercise = object

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -1,6 +1,6 @@
 # This module contains tests for `src/probspecs.nim`
 import std/[json, os, osproc, strformat, unittest]
-import cli, probspecs
+import "."/[cli, sync/probspecs]
 
 type
   ProblemSpecsDir = enum


### PR DESCRIPTION
This will make the code easier to navigate as we add more commands.

Later on, it will be easier to identify the parts of the current `sync`
code that should be shared between commands - we can then refactor that
code and move it back to the `src` directory.

This commit also tweaks the import style, with imports in this order:
- stdlib imports
- nimble imports
- imports from another directory
- imports from the same directory

Putting square brackets around a single import is probably a bit
idiosyncratic. But maybe it helps readability to make all imports look
the same, and makes diffs less noisy later on.

I didn't move the `tests/test_probspecs.nim` file to a `tests/sync`
directory. Maybe that'd be better in the long run.