### PR TITLE
fetch-configlet_v3: Use `#!/usr/bin/env bash`

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
This makes the script more portable.

We also made this change in the `configlet` repo. See https://github.com/exercism/configlet/commit/e13f7c74c1d6840ecf92e746aa32dec12cb5febb