### PR TITLE
fetch-configlet_v3: Use an array for curl options

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -25,17 +25,20 @@ case "$(uname -m)" in
     (*)     ARCH='64bit' ;;
 esac
 
+curlopts=(
+    --silent
+    --location
+)
+
 if [ -z "${GITHUB_TOKEN}" ]
 then
-    HEADER=''
-else
-    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+    curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
 SUFFIX="${OS}-${ARCH}.${EXT}"
 
 get_url () {
-    curl --header "$HEADER" -s --location "$LATEST" |
+    curl "${curlopts[@]}" "$LATEST" |
         grep "\"browser_download_url\": \".*/download/.*/configlet.*${SUFFIX}\"$" |
         cut -d'"' -f4
 }
@@ -44,9 +47,9 @@ URL=$(get_url)
 
 case "$EXT" in
     (*zip)
-        curl --header "$HEADER" -s --location "$URL" -o bin/latest-configlet.zip
+        curl "${curlopts[@]}" "$URL" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
+    (*) curl "${curlopts[@]}" "$URL" | tar xz -C bin/ ;;
 esac


### PR DESCRIPTION
Advantages of using an array here:
- It gives us a single source of truth for the options that are shared
  between the `curl` commands, which is especially useful as we add more
  options.
- It helps us to write the `curl` options in `--long-option` form.
- We can remove the `HEADER` variable, which would otherwise need to be
  renamed when we add more headers.

Note that `curl` does not accept the syntax of `--long-option=val`.

See:
- https://google.github.io/styleguide/shellguide.html#arrays
- https://mywiki.wooledge.org/BashFAQ/050
- https://github.com/koalaman/shellcheck/wiki/SC2086
- https://github.com/koalaman/shellcheck/wiki/SC2089

Edit: See below for background on the syntax used in `('--header' "authorization: Bearer ${GITHUB_TOKEN}")`
- https://stackoverflow.com/questions/46449949/using-a-bash-variable-to-pass-multiple-headers-to-curl-command/46450091#46450091
- https://stackoverflow.com/questions/28705723/bash-how-to-pass-array-items-as-options/28706295#28706295