### PR TITLE
fetch-configlet_v3: Add `-Sf` flags to curl

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -27,6 +27,8 @@ esac
 
 curlopts=(
     --silent
+    --show-error
+    --fail
     --location
 )
 


### PR DESCRIPTION
Summary:
- Add the `-S, --show-error` flag. When combined with the existing
  `-s, --silent` flag, this hides curl's progress meter without hiding
  error messages.
- Add the `-f, --fail` flag. This helps to stop curl from piping
  non-useful output into `grep` or `tar` in the case of failure.

See:
- https://curl.se/docs/manpage.html#-S
- https://curl.se/docs/manpage.html#-f

I believe that these flags would've helped when we were debugging the
issue that was solved by https://github.com/exercism/configlet/pull/174