### PR TITLE
fetch-configlet_v3: Request a specific GitHub API version

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -40,7 +40,7 @@ fi
 SUFFIX="${OS}-${ARCH}.${EXT}"
 
 get_url () {
-    curl "${curlopts[@]}" "$LATEST" |
+    curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "$LATEST" |
         grep "\"browser_download_url\": \".*/download/.*/configlet.*${SUFFIX}\"$" |
         cut -d'"' -f4
 }


### PR DESCRIPTION
The commit adds a header to our API request.

From the GitHub Docs:
> Important: The default version of the API may change in the future. If
> you're building an application and care about the stability of the
> API, be sure to request a specific version in the Accept header

See:
- https://docs.github.com/en/free-pro-team@latest/rest/overview/media-types
- https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-a-release