### PR TITLE
fetch-configlet_v3: Fix new bug in token handling

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -32,7 +32,7 @@ curlopts=(
     --location
 )
 
-if [ -z "${GITHUB_TOKEN}" ]
+if [ -n "${GITHUB_TOKEN}" ]
 then
     curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
 fi


### PR DESCRIPTION
Oops. This is what I meant to write in https://github.com/exercism/canonical-data-syncer/pull/102.