### PR TITLE
build: Tidy up scripts

### DIFF
--- a/.github/bin/build
+++ b/.github/bin/build
@@ -2,7 +2,7 @@
 
 nimble install -d -Y
 
-case "$OS" in
+case "${OS}" in
   windows)
     nimble build -d:release --opt:size --passC:'-flto' --passL='-s' --passL='-static'
     ;;

--- a/.github/bin/create-artifact
+++ b/.github/bin/create-artifact
@@ -1,23 +1,23 @@
 #!/usr/bin/env sh
 
-ARTIFACTS_DIR="artifacts"
-mkdir -p $ARTIFACTS_DIR
+artifacts_dir='artifacts'
+mkdir -p "${artifacts_dir}"
 
-BINARY_NAME="configlet_v3"
+binary_name='configlet_v3'
 
-case "$OS" in
+case "${OS}" in
   windows)
-    ARTIFACT_FILE="$ARTIFACTS_DIR/$BINARY_NAME-$OS-$ARCH.zip"
-    7z a $ARTIFACT_FILE $BINARY_NAME.exe
+    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.zip"
+    7z a "${artifact_file}" "${binary_name}.exe"
     ;;
   linux)
-    ARTIFACT_FILE="$ARTIFACTS_DIR/$BINARY_NAME-$OS-$ARCH.tgz"
-    tar -cvzf $ARTIFACT_FILE $BINARY_NAME
+    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.tgz"
+    tar -cvzf "${artifact_file}" "${binary_name}"
     ;;
   mac)
-    ARTIFACT_FILE="$ARTIFACTS_DIR/$BINARY_NAME-$OS-$ARCH.tgz"
-    tar -cvzf $ARTIFACT_FILE $BINARY_NAME
+    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.tgz"
+    tar -cvzf "${artifact_file}" "${binary_name}"
     ;;
 esac
 
-echo "ARTIFACT_FILE=${ARTIFACT_FILE}" >> "${GITHUB_ENV}"
+echo "ARTIFACT_FILE=${artifact_file}" >> "${GITHUB_ENV}"

--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-VERSION=$(echo $REF | cut -d "/" -f3)
+version="$(echo "${REF}" | cut -d'/' -f3)"
 
-gh release create $VERSION
-gh release upload $VERSION $ARTIFACT_FILE
+gh release create "${version}"
+gh release upload "${version}" "${ARTIFACT_FILE}"

--- a/bin/format
+++ b/bin/format
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-nimpretty **/*.nim
+nimpretty ./**/*.nim

--- a/bin/release
+++ b/bin/release
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-BUMP="minor"
-MESSAGE="$(git log --oneline --format=%B -n 1 HEAD | head -n 1)"
+level='minor'
+message="$(git log --oneline --format=%B -n 1 HEAD | head -n 1)"
 
 while [[ $# -gt 0 ]]
 do
   case "$1" in
     -b|--bump)
-      BUMP="$2"
+      level="$2"
       shift
       shift
     ;;
     -m|--message)
-      MESSAGE="$2"
+      message="$2"
       shift
       shift
     ;;
@@ -23,4 +23,4 @@ do
 done
 
 nimble install -Y bump
-bump --v --$BUMP "$MESSAGE"
+bump --v --"${level}" "${message}"


### PR DESCRIPTION
This commit allows us to add `shellcheck` to CI in a later commit.

Changes:
- Double-quote variable expansions (resolves SC2086 shellcheck
  warnings).
- Use lowercase for script-scoped variables, leaving uppercase for
  environmental variables.
- Prefer `"${my_variable}"` to `"$my_variable"`.
- Resolve SC2035 warning in `bin/format`.

`shellcheck` action output after this commit:
```
Run ludeeus/action-shellcheck@master
Files: ./.github/bin/publish-release ./.github/bin/create-artifact ./.github/bin/linux-install-build-tools ./.github/bin/build ./scripts/fetch-configlet_v3 ./bin/release ./bin/format
Excluded: ! -path *./.git/* ! -path *.go ! -path */mvnw
Options: 
Status code: 0
```

And before this commit:
```
In ./.github/bin/publish-release line 3:
VERSION=$(echo $REF | cut -d "/" -f3)
Error:                ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
VERSION=$(echo "$REF" | cut -d "/" -f3)


In ./.github/bin/publish-release line 5:
gh release create $VERSION
Error:                   ^------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
gh release create "$VERSION"


In ./.github/bin/publish-release line 6:
gh release upload $VERSION $ARTIFACT_FILE
Error:                   ^------^ SC2086: Double quote to prevent globbing and word splitting.
                           ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
gh release upload "$VERSION" "$ARTIFACT_FILE"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./.github/bin/create-artifact line 11:
    7z a $ARTIFACT_FILE $BINARY_NAME.exe
Error:          ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
    7z a "$ARTIFACT_FILE" $BINARY_NAME.exe


In ./.github/bin/create-artifact line 15:
    tar -cvzf $ARTIFACT_FILE $BINARY_NAME
Error:               ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
    tar -cvzf "$ARTIFACT_FILE" $BINARY_NAME


In ./.github/bin/create-artifact line 19:
    tar -cvzf $ARTIFACT_FILE $BINARY_NAME
Error:               ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
    tar -cvzf "$ARTIFACT_FILE" $BINARY_NAME

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./bin/release line 26:
bump --v --$BUMP "$MESSAGE"
Error:            ^---^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
bump --v --"$BUMP" "$MESSAGE"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./bin/format line 3:
nimpretty **/*.nim
Error:           ^-- SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options.

For more information:
  https://www.shellcheck.net/wiki/SC2035 -- Use ./*glob* or -- *glob* so name...
Files: ./.github/bin/publish-release ./.github/bin/create-artifact ./.github/bin/linux-install-build-tools ./.github/bin/build ./scripts/fetch-configlet_v3 ./bin/release ./bin/format
Excluded: ! -path *./.git/* ! -path *.go ! -path */mvnw
Options: 
Status code: 1
Error: Process completed with exit code 1.
```