### PR TITLE
CI: Add shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,13 @@
+name: shellcheck
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    name: Run shellcheck on scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@d586102c117f97e63d7e3b56629d269efc9a7c60 # 1.0.0


### PR DESCRIPTION
This causes CI to indicate failure if `shellcheck` has any complaint
about any of our scripts.

Note that we can't write

```yml
      - name: Run shellcheck
        uses: ludeeus/action-shellcheck@v1
```

because the `v1` tag doesn't exist, even though the latest version is `1.0.0`.