### PR TITLE
fetch-configlet_v3: Improve style

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -46,11 +46,11 @@ get_download_url() {
 
 download_url="$(get_download_url)"
 output_path="bin/latest-configlet.${ext}"
-curl "${curlopts[@]}" "${download_url}" -o "${output_path}"
+curl "${curlopts[@]}" -o "${output_path}" "${download_url}"
 
 case "${ext}" in
-    *zip) unzip "${output_path}" -d bin/   ;;
-    *)    tar xzf "${output_path}" -C bin/ ;;
+    *zip) unzip -d bin/ "${output_path}"   ;;
+    *)    tar xzf -C bin/ "${output_path}" ;;
 esac
 
 rm -f "${output_path}"

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -13,7 +13,7 @@ case "$(uname)" in
     (*)         os='linux'   ;;
 esac
 
-case "$os" in
+case "${os}" in
     (windows*) ext='zip' ;;
     (*)        ext='tgz' ;;
 esac
@@ -40,18 +40,18 @@ fi
 suffix="${os}-${arch}.${ext}"
 
 get_url () {
-    curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "$LATEST" |
+    curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
         grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
         cut -d'"' -f4
 }
 
 url=$(get_url)
 
-case "$ext" in
+case "${ext}" in
     (*zip)
-        curl "${curlopts[@]}" "$url" -o bin/latest-configlet.zip
+        curl "${curlopts[@]}" "${url}" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl "${curlopts[@]}" "$url" | tar xzf - -C bin/ ;;
+    (*) curl "${curlopts[@]}" "${url}" | tar xzf - -C bin/ ;;
 esac

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -45,12 +45,12 @@ get_download_url() {
 }
 
 download_url="$(get_download_url)"
+output_path="bin/latest-configlet.${ext}"
+curl "${curlopts[@]}" "${download_url}" -o "${output_path}"
 
 case "${ext}" in
-    *zip)
-        curl "${curlopts[@]}" "${download_url}" -o bin/latest-configlet.zip
-        unzip bin/latest-configlet.zip -d bin/
-        rm bin/latest-configlet.zip
-        ;;
-    *) curl "${curlopts[@]}" "${download_url}" | tar xzf - -C bin/ ;;
+    *zip) unzip "${output_path}" -d bin/   ;;
+    *)    tar xzf "${output_path}" -C bin/ ;;
 esac
+
+rm -f "${output_path}"

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -5,24 +5,24 @@ set -eo pipefail
 readonly LATEST='https://api.github.com/repos/exercism/configlet-v3/releases/latest'
 
 case "$(uname)" in
-    (Darwin*)   OS='mac'     ;;
-    (Linux*)    OS='linux'   ;;
-    (Windows*)  OS='windows' ;;
-    (MINGW*)    OS='windows' ;;
-    (MSYS_NT-*) OS='windows' ;;
-    (*)         OS='linux'   ;;
+    (Darwin*)   os='mac'     ;;
+    (Linux*)    os='linux'   ;;
+    (Windows*)  os='windows' ;;
+    (MINGW*)    os='windows' ;;
+    (MSYS_NT-*) os='windows' ;;
+    (*)         os='linux'   ;;
 esac
 
-case "$OS" in
-    (windows*) EXT='zip' ;;
-    (*)        EXT='tgz' ;;
+case "$os" in
+    (windows*) ext='zip' ;;
+    (*)        ext='tgz' ;;
 esac
 
 case "$(uname -m)" in
-    (*64*)  ARCH='64bit' ;;
-    (*686*) ARCH='32bit' ;;
-    (*386*) ARCH='32bit' ;;
-    (*)     ARCH='64bit' ;;
+    (*64*)  arch='64bit' ;;
+    (*686*) arch='32bit' ;;
+    (*386*) arch='32bit' ;;
+    (*)     arch='64bit' ;;
 esac
 
 curlopts=(
@@ -37,21 +37,21 @@ then
     curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
-SUFFIX="${OS}-${ARCH}.${EXT}"
+suffix="${os}-${arch}.${ext}"
 
 get_url () {
     curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "$LATEST" |
-        grep "\"browser_download_url\": \".*/download/.*/configlet.*${SUFFIX}\"$" |
+        grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
         cut -d'"' -f4
 }
 
-URL=$(get_url)
+url=$(get_url)
 
-case "$EXT" in
+case "$ext" in
     (*zip)
-        curl "${curlopts[@]}" "$URL" -o bin/latest-configlet.zip
+        curl "${curlopts[@]}" "$url" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl "${curlopts[@]}" "$URL" | tar xzf - -C bin/ ;;
+    (*) curl "${curlopts[@]}" "$url" | tar xzf - -C bin/ ;;
 esac

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -32,8 +32,7 @@ curlopts=(
     --location
 )
 
-if [ -n "${GITHUB_TOKEN}" ]
-then
+if [ -n "${GITHUB_TOKEN}" ]; then
     curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -39,19 +39,19 @@ fi
 
 suffix="${os}-${arch}.${ext}"
 
-get_url () {
+get_download_url () {
     curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
         grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
         cut -d'"' -f4
 }
 
-url=$(get_url)
+download_url=$(get_download_url)
 
 case "${ext}" in
     (*zip)
-        curl "${curlopts[@]}" "${url}" -o bin/latest-configlet.zip
+        curl "${curlopts[@]}" "${download_url}" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl "${curlopts[@]}" "${url}" | tar xzf - -C bin/ ;;
+    (*) curl "${curlopts[@]}" "${download_url}" | tar xzf - -C bin/ ;;
 esac

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -33,7 +33,7 @@ curlopts=(
 )
 
 if [[ -n "${GITHUB_TOKEN}" ]]; then
-  curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
+  curlopts+=(--header "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
 suffix="${os}-${arch}.${ext}"

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -39,7 +39,7 @@ fi
 
 suffix="${os}-${arch}.${ext}"
 
-get_download_url () {
+get_download_url() {
     curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
         grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
         cut -d'"' -f4

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -5,24 +5,24 @@ set -eo pipefail
 readonly LATEST='https://api.github.com/repos/exercism/configlet-v3/releases/latest'
 
 case "$(uname)" in
-    (Darwin*)   os='mac'     ;;
-    (Linux*)    os='linux'   ;;
-    (Windows*)  os='windows' ;;
-    (MINGW*)    os='windows' ;;
-    (MSYS_NT-*) os='windows' ;;
-    (*)         os='linux'   ;;
+    Darwin*)   os='mac'     ;;
+    Linux*)    os='linux'   ;;
+    Windows*)  os='windows' ;;
+    MINGW*)    os='windows' ;;
+    MSYS_NT-*) os='windows' ;;
+    *)         os='linux'   ;;
 esac
 
 case "${os}" in
-    (windows*) ext='zip' ;;
-    (*)        ext='tgz' ;;
+    windows*) ext='zip' ;;
+    *)        ext='tgz' ;;
 esac
 
 case "$(uname -m)" in
-    (*64*)  arch='64bit' ;;
-    (*686*) arch='32bit' ;;
-    (*386*) arch='32bit' ;;
-    (*)     arch='64bit' ;;
+    *64*)  arch='64bit' ;;
+    *686*) arch='32bit' ;;
+    *386*) arch='32bit' ;;
+    *)     arch='64bit' ;;
 esac
 
 curlopts=(
@@ -47,10 +47,10 @@ get_download_url() {
 download_url="$(get_download_url)"
 
 case "${ext}" in
-    (*zip)
+    *zip)
         curl "${curlopts[@]}" "${download_url}" -o bin/latest-configlet.zip
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl "${curlopts[@]}" "${download_url}" | tar xzf - -C bin/ ;;
+    *) curl "${curlopts[@]}" "${download_url}" | tar xzf - -C bin/ ;;
 esac

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -5,43 +5,43 @@ set -eo pipefail
 readonly LATEST='https://api.github.com/repos/exercism/configlet-v3/releases/latest'
 
 case "$(uname)" in
-    Darwin*)   os='mac'     ;;
-    Linux*)    os='linux'   ;;
-    Windows*)  os='windows' ;;
-    MINGW*)    os='windows' ;;
-    MSYS_NT-*) os='windows' ;;
-    *)         os='linux'   ;;
+  Darwin*)   os='mac'     ;;
+  Linux*)    os='linux'   ;;
+  Windows*)  os='windows' ;;
+  MINGW*)    os='windows' ;;
+  MSYS_NT-*) os='windows' ;;
+  *)         os='linux'   ;;
 esac
 
 case "${os}" in
-    windows*) ext='zip' ;;
-    *)        ext='tgz' ;;
+  windows*) ext='zip' ;;
+  *)        ext='tgz' ;;
 esac
 
 case "$(uname -m)" in
-    *64*)  arch='64bit' ;;
-    *686*) arch='32bit' ;;
-    *386*) arch='32bit' ;;
-    *)     arch='64bit' ;;
+  *64*)  arch='64bit' ;;
+  *686*) arch='32bit' ;;
+  *386*) arch='32bit' ;;
+  *)     arch='64bit' ;;
 esac
 
 curlopts=(
-    --silent
-    --show-error
-    --fail
-    --location
+  --silent
+  --show-error
+  --fail
+  --location
 )
 
 if [[ -n "${GITHUB_TOKEN}" ]]; then
-    curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
+  curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
 suffix="${os}-${arch}.${ext}"
 
 get_download_url() {
-    curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
-        grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
-        cut -d'"' -f4
+  curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
+    grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
+    cut -d'"' -f4
 }
 
 download_url="$(get_download_url)"
@@ -49,8 +49,8 @@ output_path="bin/latest-configlet.${ext}"
 curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 
 case "${ext}" in
-    *zip) unzip -d bin/ "${output_path}"   ;;
-    *)    tar xzf -C bin/ "${output_path}" ;;
+  *zip) unzip -d bin/ "${output_path}"   ;;
+  *)    tar xzf -C bin/ "${output_path}" ;;
 esac
 
 rm -f "${output_path}"

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -45,7 +45,7 @@ get_download_url () {
         cut -d'"' -f4
 }
 
-download_url=$(get_download_url)
+download_url="$(get_download_url)"
 
 case "${ext}" in
     (*zip)

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -46,7 +46,7 @@ get_download_url() {
 
 download_url="$(get_download_url)"
 output_path="bin/latest-configlet.${ext}"
-curl "${curlopts[@]}" -o "${output_path}" "${download_url}"
+curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 
 case "${ext}" in
     *zip) unzip -d bin/ "${output_path}"   ;;

--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -32,7 +32,7 @@ curlopts=(
     --location
 )
 
-if [ -n "${GITHUB_TOKEN}" ]; then
+if [[ -n "${GITHUB_TOKEN}" ]]; then
     curlopts+=('--header' "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 


### PR DESCRIPTION
The commits are atomic - please see the commit messages. (I'd prefer to squash this PR, though).

@IsaacG very kindly gave me a detailed review of the first 6 commits here and suggested the changes given by:
- https://github.com/exercism/canonical-data-syncer/commit/f393d8a7be4c5d9017d67ad9b4346830f817755c ```fetch-configlet_v3: Remove `(` in case statements```
- https://github.com/exercism/canonical-data-syncer/commit/550a4c3e8b63dd33ec3ccf77c771792c1a6d3ee5 ```fetch-configlet_v3: Prefer `[[` to `[` ```
- https://github.com/exercism/canonical-data-syncer/commit/97e852d00e1896ad5e271929e7a2ba585352161c ```fetch-configlet_v3: Move options before arguments```

The commit https://github.com/exercism/canonical-data-syncer/commit/774305f64bd5eb12618d7aaf92026074c8418164 attempts to address some of their other comments, but it wasn't reviewed.

Note that we indent using 2 spaces in [the version of this script in exercism/github-actions](https://github.com/exercism/github-actions/blob/57e87fda9c1d28cabc58f83f517aabbc59fa8c36/configlet-ci/fetch-configlet) and in our other scripts in this repo:
https://github.com/exercism/canonical-data-syncer/blob/7edf852ae6f4fd382be402d43dda81ee1a92e9a4/bin/release#L8-L10
https://github.com/exercism/canonical-data-syncer/blob/7edf852ae6f4fd382be402d43dda81ee1a92e9a4/.github/bin/build#L5-L7
https://github.com/exercism/canonical-data-syncer/blob/7edf852ae6f4fd382be402d43dda81ee1a92e9a4/.github/bin/create-artifact#L8-L10