### PR TITLE
fetch-configlet_v3: Improve portability

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -53,5 +53,5 @@ case "$EXT" in
         unzip bin/latest-configlet.zip -d bin/
         rm bin/latest-configlet.zip
         ;;
-    (*) curl "${curlopts[@]}" "$URL" | tar xz -C bin/ ;;
+    (*) curl "${curlopts[@]}" "$URL" | tar xzf - -C bin/ ;;
 esac


### PR DESCRIPTION
Our `tar` command should contain `f -` to specify reading from stdin, as
some `tar` implementations do not read from stdin by default otherwise.
I believe the script would previously hang or fail on some platforms
(for example, some BSDs).

The script also wouldn't work on any platform that had the `TAPE`
environmental variable set.

See e.g.:
- https://www.gnu.org/software/tar/manual/html_node/file.html
- https://man.openbsd.org/tar#f
- https://unix.stackexchange.com/questions/529318

I'll also fix this in [the version of this script in the github-actions repo](https://github.com/exercism/github-actions/blob/57e87fda9c1d28cabc58f83f517aabbc59fa8c36/configlet-ci/fetch-configlet#L19)