### PR TITLE
fetch-configlet_v3: Add retry to curl options

### DIFF
--- a/scripts/fetch-configlet_v3
+++ b/scripts/fetch-configlet_v3
@@ -30,6 +30,7 @@ curlopts=(
   --show-error
   --fail
   --location
+  --retry 3
 )
 
 if [[ -n "${GITHUB_TOKEN}" ]]; then


### PR DESCRIPTION
See https://curl.se/docs/manpage.html#--retry

> If a transient error is returned when curl tries to perform a transfer, it will retry this number of times before giving up. Setting the number to 0 makes curl do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408, 429 or 5xx response code.

> When curl is about to retry a transfer, it will first wait one second and then for all forthcoming retries it will double the waiting time until it reaches 10 minutes

This PR means that `curl` will request once, and if it fails, try again at 1, 2 and 4 second intervals.