### PR TITLE
Chore: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  # Enable updates to the dependencies of our workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Do we want this?

---
Dependabot will now create a PR on the first day of every month for any
outdated GitHub Action that we use in a workflow.

The current list of GitHub Actions that we use is:
- actions/checkout
- jiro4989/setup-nim-action
- ludeeus/action-shellcheck