### PR TITLE
fetch-configlet: update PowerShell version to match shell version

### DIFF
--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 Function DownloadUrl ([string] $FileName, $Headers) {
     $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
     $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl -MaximumRetryCount 3 -RetryIntervalSec 1 -PreserveAuthorizationOnRedirect

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -20,8 +20,10 @@ $requestOpts = @{
 
 Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
-    $json = Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts
-    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
+    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts
+    | Select-Object -ExpandProperty assets
+    | Where-Object { $_.browser_download_url -match $FileName }
+    | Select-Object -ExpandProperty browser_download_url
 }
 
 $downloadUrl = Get-DownloadUrl

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,22 +1,13 @@
 $ErrorActionPreference = "Stop"
 
-Function Headers {
-    If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
-}
-
-Function Arch {
-    If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
-}
-
-$headers = Headers
-$arch = Arch
-$fileName = "configlet-windows-$arch.zip"
-
 $requestOpts = @{
-    Headers = $headers
+    Headers = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
     MaximumRetryCount = 3
     RetryIntervalSec = 1
 }
+
+$arch = If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
+$fileName = "configlet-windows-$arch.zip"
 
 Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -9,18 +9,18 @@ Function Arch {
 }
 
 $headers = Headers
-$requestOpts = @{
-  Headers = Headers
-  MaximumRetryCount = 3
-  RetryIntervalSec = 1
-  PreserveAuthorizationOnRedirect = $true
-}
 $arch = Arch
 $fileName = "configlet-windows-$arch.zip"
 
+$requestOpts = @{
+    Headers = $headers
+    MaximumRetryCount = 3
+    RetryIntervalSec = 1
+}
+
 Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
-    $json = Invoke-RestMethod -Uri $latestUrl @requestOpts
+    $json = Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts
     $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
 }
 

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,6 +1,6 @@
 Function DownloadUrl ([string] $FileName, $Headers) {
     $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
-    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl -MaximumRetryCount 3 -RetryIntervalSec 1
+    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl -MaximumRetryCount 3 -RetryIntervalSec 1 -PreserveAuthorizationOnRedirect
     $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
 }
 
@@ -19,6 +19,6 @@ $outputDirectory = "bin"
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
 $zipUrl = DownloadUrl -FileName $fileName -Headers $headers
 
-Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile -MaximumRetryCount 3 -RetryIntervalSec 1
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile -MaximumRetryCount 3 -RetryIntervalSec 1 -PreserveAuthorizationOnRedirect
 Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
 Remove-Item -Path $outputFile

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,6 +1,6 @@
 Function DownloadUrl ([string] $FileName, $Headers) {
     $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
-    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl
+    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl -MaximumRetryCount 3 -RetryIntervalSec 1
     $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
 }
 
@@ -19,6 +19,6 @@ $outputDirectory = "bin"
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
 $zipUrl = DownloadUrl -FileName $fileName -Headers $headers
 
-Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile -MaximumRetryCount 3 -RetryIntervalSec 1
 Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
 Remove-Item -Path $outputFile

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -7,7 +7,7 @@ Function DownloadUrl ([string] $FileName, $Headers) {
 }
 
 Function Headers {
-    If ($GITHUB_TOKEN) { @{ Authorization = "Bearer ${GITHUB_TOKEN}" } } Else { @{ } }
+    If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
 }
 
 Function Arch {

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,11 +1,5 @@
 $ErrorActionPreference = "Stop"
 
-Function DownloadUrl ([string] $FileName, $Headers) {
-    $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
-    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl -MaximumRetryCount 3 -RetryIntervalSec 1 -PreserveAuthorizationOnRedirect
-    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
-}
-
 Function Headers {
     If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
 }
@@ -14,13 +8,25 @@ Function Arch {
     If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
 }
 
-$arch = Arch
 $headers = Headers
+$requestOpts = @{
+  Headers = Headers
+  MaximumRetryCount = 3
+  RetryIntervalSec = 1
+  PreserveAuthorizationOnRedirect = $true
+}
+$arch = Arch
 $fileName = "configlet-windows-$arch.zip"
+
+Function Get-DownloadUrl {
+    $latestUrl = "https://api.github.com/repos/exercism/configlet-v3/releases/latest"
+    $json = Invoke-RestMethod -Uri $latestUrl @requestOpts
+    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
+}
+
+$downloadUrl = Get-DownloadUrl
 $outputDirectory = "bin"
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
-$zipUrl = DownloadUrl -FileName $fileName -Headers $headers
-
-Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile -MaximumRetryCount 3 -RetryIntervalSec 1 -PreserveAuthorizationOnRedirect
+Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
 Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
 Remove-Item -Path $outputFile


### PR DESCRIPTION
There were quite some differences between the shell version of fetch_configlet and the powershell version. This fixes those.

- fetch-configlet: add retry count
- fetch-configlet: preserve authorization header on redirects
- fetch-configlet: stop when any error occurs
- fetch-configlet: fix authorization header not passed
- fetch-configlet: pass parameters as splat
- fetch-configlet: Use shared request options
- fetch-configlet: use pipe to simplify JSON processing
- fetch-configlet: inline if-statements
