### PR TITLE
git: ignore tests binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@
 # Application binary
 configlet
 
+# Tests binary
+all_tests
+
 # Temporary prob-specs repo
 .problem-specifications/


### PR DESCRIPTION
Currently, running the tests using `nim c-r ./tests/all_tests.nim` results in a binary file being produced. This PR updates the .gitignore file to ignore said tests binary.
