### PR TITLE
lint: Add stub implementation

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -14,12 +14,15 @@ type
 
   ActionKind* = enum
     actNil = "nil"
+    actLint = "lint"
     actSync = "sync"
     actUuid = "uuid"
 
   Action* = object
     case kind*: ActionKind
     of actNil:
+      discard
+    of actLint:
       discard
     of actSync:
       exercise*: string
@@ -203,6 +206,8 @@ func initAction*(actionKind: ActionKind, probSpecsDir = ""): Action =
   case actionKind
   of actNil:
     Action(kind: actionKind)
+  of actLint:
+    Action(kind: actionKind)
   of actSync:
     Action(kind: actionKind, probSpecsDir: probSpecsDir)
   of actUuid:
@@ -315,6 +320,8 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
     case conf.action.kind
     of actNil:
       discard
+    of actLint:
+      discard
     of actSync:
       case opt
       of optSyncExercise:
@@ -365,6 +372,8 @@ proc processCmdLine*: Conf =
   case result.action.kind
   of actNil:
     showHelp()
+  of actLint:
+    discard
   of actSync:
     if result.action.offline and result.action.probSpecsDir.len == 0:
       showError(&"'{list(optSyncOffline)}' was given without passing " &

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,5 +1,5 @@
 import std/[posix]
-import "."/[cli, logger, sync/check, sync/sync, uuid/uuid]
+import "."/[cli, lint/lint, logger, sync/check, sync/sync, uuid/uuid]
 
 proc main =
   onSignal(SIGTERM):
@@ -12,6 +12,8 @@ proc main =
   case conf.action.kind
   of actNil:
     discard
+  of actLint:
+    lint()
   of actSync:
     if conf.action.check:
       check(conf)

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,0 +1,5 @@
+proc lint*() =
+  stdout.writeLine "No linting rules have yet been implemented.\n" &
+                   "As we're in the process of implementing the linting rules, " &
+                   "please re-run this command regularly to see if your track " &
+                   "passes the latest linting rules."

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,5 +1,5 @@
-proc lint*() =
-  stdout.writeLine "No linting rules have yet been implemented.\n" &
-                   "As we're in the process of implementing the linting rules, " &
-                   "please re-run this command regularly to see if your track " &
-                   "passes the latest linting rules."
+proc lint* =
+  echo "No linting rules have yet been implemented.\n" &
+       "As we're in the process of implementing the linting rules, please " &
+       "re-run this command regularly to see if your track passes the " &
+       "latest linting rules."


### PR DESCRIPTION
This PR is based off https://github.com/exercism/canonical-data-syncer/pull/106, so it should only be merged after that PR is merged.

In this PR, a minimal stub implementation of the `lint` command is added. My goals with this PR are as follows:

- Output a friendly error to tracks when they try to run `configlet lint` (which will be sooner rather than later)
- Let tracks know that we're busy implementing the linting rules and that they thus need to re-run the check regularly
- Provide a base for others to also start working on the linter. Admittedly, this doesn't help much at the moment, but it is _a_ start.

I've deliberately not added any actual linting rule implementations or tests.