### PR TITLE
sync: refactor writing of `tests.toml`

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -89,7 +89,7 @@ proc toToml(exercise: Exercise): string =
     result.add(&"\n# {testCase.description}")
     result.add(&"\n\"{testCase.uuid}\" = {isIncluded}\n")
 
-proc writeFile*(exercise: Exercise) =
+proc writeTestsToml*(exercise: Exercise) =
   let testsPath = testsFile(exercise)
   createDir(testsPath.parentDir())
 

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -92,5 +92,4 @@ proc toToml(exercise: Exercise): string =
 proc writeFile*(exercise: Exercise) =
   createDir(parentDir(exercise.testsFile))
 
-  let file = open(exercise.testsFile, fmWrite)
-  write(file, exercise.toToml())
+  writeFile(exercise.testsFile, exercise.toToml())

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -90,6 +90,8 @@ proc toToml(exercise: Exercise): string =
     result.add(&"\n\"{testCase.uuid}\" = {isIncluded}\n")
 
 proc writeFile*(exercise: Exercise) =
-  createDir(parentDir(exercise.testsFile))
+  let testsPath = testsFile(exercise)
+  createDir(testsPath.parentDir())
 
-  writeFile(exercise.testsFile, exercise.toToml())
+  let contents = toToml(exercise)
+  writeFile(testsPath, contents)

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -100,7 +100,7 @@ proc sync(exercise: Exercise, mode: Mode): Exercise =
 
   result.tests = initExerciseTests(included, excluded, missing)
 
-  writeFile(result)
+  writeTestsToml(result)
 
 proc sync(exercises: seq[Exercise], mode: Mode): seq[Exercise] =
   for exercise in exercises:


### PR DESCRIPTION
If this is approved, I'll squash this.

While working on #72 I didn't want to add a second parameter to a proc named `writeFile`, so I'd prefer to merge something like this PR first.

Feel free to bikeshed.