### PR TITLE
Fix fetch configlet script

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -50,8 +50,8 @@ output_path="bin/latest-configlet.${ext}"
 curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 
 case "${ext}" in
-  *zip) unzip -d bin/ "${output_path}"   ;;
-  *)    tar xzf -C bin/ "${output_path}" ;;
+  *zip) unzip "${output_path}" -d bin/   ;;
+  *)    tar xzf "${output_path}" -C bin/ ;;
 esac
 
 rm -f "${output_path}"

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -46,12 +46,13 @@ get_download_url() {
 }
 
 download_url="$(get_download_url)"
-output_path="bin/latest-configlet.${ext}"
+output_dir="bin"
+output_path="${output_dir}/latest-configlet.${ext}"
 curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 
 case "${ext}" in
-  *zip) unzip "${output_path}" -d bin/   ;;
-  *)    tar xzf "${output_path}" -C bin/ ;;
+  *zip) unzip "${output_path}" -d "${output_dir}"   ;;
+  *)    tar xzf "${output_path}" -C "${output_dir}" ;;
 esac
 
 rm -f "${output_path}"


### PR DESCRIPTION
While testing the `fetch-configlet` script, I found that it didn't work:

```
tar (child): -C: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

This turned out to be due to the arguments being in the wrong order.

I've also added a second commit to introduce a variable for the output directory, which makes it more concistent with the PowerShell script and reduce duplication.