### PR TITLE
build: bump Nim from 1.4.0 to 1.4.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@de456899a933296efa9d86e050300c1d9cc7e446 # 1.3.0
         with:
-          nim-version: "1.4.0"
+          nim-version: "1.4.2"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@de456899a933296efa9d86e050300c1d9cc7e446 # 1.3.0
         with:
-          nim-version: "1.4.0"
+          nim-version: "1.4.2"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -7,7 +7,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.4.0"
+requires "nim >= 1.4.2"
 requires "parsetoml"
 requires "cligen"
 requires "uuids >= 0.1.11"


### PR DESCRIPTION
Blog post: https://nim-lang.org/blog/2020/12/01/version-142-released.html

This also enforces that a contributor has the latest stable version of Nim installed.

With this PR:
```
$ git grep --heading --break "1\.4"
.github/workflows/build.yml
41:          nim-version: "1.4.2"

.github/workflows/tests.yml
37:          nim-version: "1.4.2"

configlet.nimble
10:requires "nim >= 1.4.2"
```