### PR TITLE
Use main instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Global options:
 
 ## Linting
 
-The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism. The full list of rules that are checked by the linter can be found [here](https://github.com/exercism/v3-docs/blob/master/anatomy/tracks/configlet/linting.md).
+The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism. The full list of rules that are checked by the linter can be found [here](https://github.com/exercism/v3-docs/blob/main/anatomy/tracks/configlet/linting.md).
 
 The `configlet lint` command is currently in the process of being implemented.
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -132,7 +132,7 @@ proc getNameOfRemote(probSpecsDir, host, location: string): string =
 proc validate(probSpecsRepo: ProbSpecsRepo) =
   ## Raises an error if the given `probSpecsRepo` is not a valid
   ## `problem-specifications` repo that is up-to-date with upstream.
-  const mainBranchName = "master"
+  const mainBranchName = "main"
 
   let probSpecsDir = probSpecsRepo.dir
   logDetailed(&"Using user-provided problem-specifications dir: {probSpecsDir}")
@@ -166,8 +166,8 @@ proc validate(probSpecsRepo: ProbSpecsRepo) =
       showError(&"failed to fetch `{mainBranchName}` in " &
                 &"problem-specifications directory: '{probSpecsDir}'")
 
-    # Allow HEAD to be on a non-`master` branch, as long as it's up-to-date
-    # with `upstream/master`.
+    # Allow HEAD to be on a non-`main` branch, as long as it's up-to-date
+    # with `upstream/main`.
     let (revHead, _) = execCmdEx("git rev-parse HEAD")
     let (revUpstream, _) = execCmdEx(&"git rev-parse {remoteName}/{mainBranchName}")
     if revHead != revUpstream:


### PR DESCRIPTION
This prepares for the renaming of the branches to main instead of master. We should hold off on merging this until the prob-specs repo's default branch has been renamed to `main.`
