### PR TITLE
sync(exercises): add `practice` to exercise path

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -76,7 +76,7 @@ proc hasCanonicalData*(exercise: Exercise): bool =
   exercise.testCases.len > 0
 
 proc testsFile(exercise: Exercise, trackDir: string): string =
-  trackDir / "exercises" / exercise.slug / ".meta" / "tests.toml"
+  trackDir / "exercises" / "practice" / exercise.slug / ".meta" / "tests.toml"
 
 proc toToml(exercise: Exercise): string =
   result.add("[canonical-tests]\n")

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -7,7 +7,7 @@ type
     slug: string
 
   ConfigJson = object
-    exercises: seq[ConfigJsonExercise]
+    practice: seq[ConfigJsonExercise]
 
   TrackRepo = object
     dir: string
@@ -37,13 +37,13 @@ proc slug(exercise: TrackRepoExercise): string =
   extractFilename(exercise.dir)
 
 proc testsFile(exercise: TrackRepoExercise): string =
-  exercise.dir / ".meta" / "tests.toml"
+  exercise.dir / "practice" / ".meta" / "tests.toml"
 
 proc testsFile*(exercise: TrackExercise): string =
   exercise.repoExercise.testsFile
 
 proc parseConfigJson(filePath: string): ConfigJson =
-  let json = json.parseFile(filePath)
+  let json = json.parseFile(filePath)["exercises"]
   to(json, ConfigJson)
 
 proc newTrackRepoExercise(repo: TrackRepo,
@@ -53,7 +53,7 @@ proc newTrackRepoExercise(repo: TrackRepo,
 proc exercises(repo: TrackRepo): seq[TrackRepoExercise] =
   let config = parseConfigJson(repo.configJsonFile)
 
-  for exercise in config.exercises:
+  for exercise in config.practice:
     result.add(newTrackRepoExercise(repo, exercise))
 
 proc newTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =


### PR DESCRIPTION
Please test this with `configlet sync --track-dir some_v3_track_repo`.

Closes: #133 