### PR TITLE
cli: suppress options for lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage:
   configlet [global-options] <command> [command-options]
 
 Commands:
-  sync, uuid
+  lint, sync, uuid
 
 Options for sync:
   -e, --exercise <slug>        Only sync this exercise

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -153,7 +153,7 @@ func genHelpText: string =
 
   var optSeen: set[Opt] = {}
   for actionKind in ActionKind:
-    if actionKind != actNil:
+    if actionKind notin {actNil, actLint}:
       result &= &"\nOptions for {actionKind}:\n"
       let action = Action(kind: actionKind)
       for key, val in fieldPairs(action):


### PR DESCRIPTION
This makes the repo `README` and the actual output of `configlet --help` converge.

I might squash this.