### PR TITLE
build: make nimble options more consistent

### DIFF
--- a/.github/bin/build
+++ b/.github/bin/build
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
-nimble install -d -Y
+nimble --accept install --depsOnly
 nimble build -d:release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install our Nimble dependencies
-        run: nimble -y install --depsOnly
+        run: nimble --accept install --depsOnly
 
       - name: Run `tests/all_tests.nim`
         run: nim c --styleCheck:error -r ./tests/all_tests.nim

--- a/bin/release
+++ b/bin/release
@@ -22,5 +22,5 @@ do
   esac
 done
 
-nimble install -Y bump
+nimble --accept install bump
 bump --v --"${level}" "${message}"


### PR DESCRIPTION
Changes:
- Prefer `--accept` over `-y` (and erroneous uppercase `-Y`)
- Prefer `--depsOnly` over `-d`
- Move nimble options before command options