### PR TITLE
build: remove `v` tag prefix

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -23,4 +23,4 @@ do
 done
 
 nimble --accept install bump
-bump --v --"${level}" "${message}"
+bump --"${level}" "${message}"


### PR DESCRIPTION
I think I have a small preference for tagging without a `v` prefix.