### PR TITLE
cli: remove `v` prefix from `--version` output

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -178,7 +178,7 @@ proc showHelp(exitCode: range[0..255] = 0) =
   quit(exitCode)
 
 proc showVersion =
-  echo &"v{NimblePkgVersion}"
+  echo &"{NimblePkgVersion}"
   quit(0)
 
 proc showError*(s: string) =

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -132,7 +132,7 @@ proc main =
       let (outp, exitCode) = execCmdEx(&"{binaryPath} --version")
       var major, minor, patch: int
       check:
-        outp.scanf("v$i.$i.$i$s$.", major, minor, patch)
+        outp.scanf("$i.$i.$i", major, minor, patch)
         exitCode == 0
 
   suite "offline":


### PR DESCRIPTION
This commit also updates the tests to support a version string like
`4.0.0-alpha.1`

This commit just changes `nimble --version` output, which probably shouldn't have had a `v` in the first place. This is independent from the PR that proposes not including the `v` prefix in git tags.