### PR TITLE
build: bump Ubuntu from 18.04 to 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
           - target:
               os: mac
             builder: macos-10.15

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   shellcheck:
     name: Run shellcheck on scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
           - target:
               os: mac
             builder: macos-10.15


### PR DESCRIPTION
Perhaps most notably, this bumps the versions of gcc and musl that are
used to create the Linux release binary.

```
gcc:   7.5.0 -> 9.3.0
musl: 1.1.19 -> 1.1.24
```

We also bump the Ubuntu version in the `shellcheck.yml` and `tests.yml`
workflows.