### PR TITLE
lint: add initial linting rules

### DIFF
--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -13,7 +13,7 @@ proc main =
   of actNil:
     discard
   of actLint:
-    lint()
+    lint(conf)
   of actSync:
     if conf.action.check:
       check(conf)

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,4 +1,4 @@
-import std/[os]
+import std/[algorithm, os]
 
 template withDir*(dir: string; body: untyped): untyped =
   ## Changes the current directory to `dir` temporarily.
@@ -8,3 +8,11 @@ template withDir*(dir: string; body: untyped): untyped =
     body
   finally:
     setCurrentDir(startDir)
+
+proc getSortedSubdirs*(dir: string): seq[string] =
+  ## Returns a seq of the subdirectories of `dir`, in alphabetical order.
+  result = newSeqOfCap[string](100)
+  for kind, path in walkDir(dir):
+    if kind == pcDir:
+      result.add path
+  sort result

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,0 +1,10 @@
+import std/[os]
+
+template withDir*(dir: string; body: untyped): untyped =
+  ## Changes the current directory to `dir` temporarily.
+  let startDir = getCurrentDir()
+  try:
+    setCurrentDir(dir)
+    body
+  finally:
+    setCurrentDir(startDir)

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,5 +1,55 @@
-proc lint* =
-  echo "No linting rules have yet been implemented.\n" &
-       "As we're in the process of implementing the linting rules, please " &
-       "re-run this command regularly to see if your track passes the " &
-       "latest linting rules."
+import std/[json, os, strformat, terminal]
+import ".."/[cli, helpers]
+
+template writeError(description: string, details: string) =
+  stdout.styledWriteLine(fgRed, description & ":")
+  stdout.writeLine(details)
+  stdout.write "\n"
+  result = false
+
+proc isValidTrackConfig(trackDir: string): bool =
+  result = true
+  let configJsonPath = trackDir / "config.json"
+  if fileExists(configJsonPath):
+    try:
+      let j = parseFile(configJsonPath)
+    except:
+      writeError("JSON parsing error", getCurrentExceptionMsg())
+  else:
+    writeError("Missing file", configJsonPath)
+
+proc conceptExerciseFilesExist(trackDir: string): bool =
+  const
+    conceptExerciseFiles = [
+      ".docs" / "hints.md",
+      ".docs" / "instructions.md",
+      ".docs" / "introduction.md",
+      ".meta" / "config.json",
+    ]
+
+  let conceptDir = trackDir / "exercises" / "concept"
+  result = true
+
+  if dirExists(conceptDir):
+    for dir in getSortedSubDirs(conceptDir):
+      for conceptExerciseFile in conceptExerciseFiles:
+        let path = dir / conceptExerciseFile
+        if not fileExists(path):
+          writeError("Missing file", path)
+
+proc lint*(conf: Conf) =
+  echo "The lint command is under development.\n"  &
+       "Please re-run this command regularly to see if your track passes " &
+       "the latest linting rules.\n"
+
+  let trackDir = conf.trackDir
+  let b1 = isValidTrackConfig(trackDir)
+  let b2 = conceptExerciseFilesExist(trackDir)
+
+  if b1 and b2:
+    echo """
+Basic linting finished successfully:
+- config.json exists and is valid JSON
+- Every concept exercise has the required .md files and a .meta/config.json file"""
+  else:
+    quit(1)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -1,5 +1,5 @@
 import std/[json, os, osproc, sequtils, strformat, strscans, strutils]
-import ".."/[cli, logger]
+import ".."/[cli, helpers, logger]
 
 type
   ProbSpecsRepoExercise = object
@@ -101,15 +101,6 @@ proc findProbSpecsExercises(repo: ProbSpecsRepo, conf: Conf): seq[ProbSpecsExerc
   for repoExercise in repo.exercisesWithCanonicalData():
     if conf.action.exercise.len == 0 or conf.action.exercise == repoExercise.slug:
       result.add(initProbSpecsExercise(repoExercise))
-
-template withDir(dir: string; body: untyped): untyped =
-  ## Changes the current directory to `dir` temporarily.
-  let startDir = getCurrentDir()
-  try:
-    setCurrentDir(dir)
-    body
-  finally:
-    setCurrentDir(startDir)
 
 proc getNameOfRemote(probSpecsDir, host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`


### PR DESCRIPTION
Extremely basic to start with.

Bad identifiers: `b1`, `b2`, `helpers`